### PR TITLE
Update Prey.download.recipe

### DIFF
--- a/PreyProject/Prey.download.recipe
+++ b/PreyProject/Prey.download.recipe
@@ -11,9 +11,9 @@
         <key>NAME</key>
         <string>Prey</string>
         <key>SEARCH_URL</key>
-        <string>https://preyproject.com/releases/current</string>
+        <string>https://preyproject.com/download</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;zip&gt;prey-(?P&lt;version&gt;.*?)-mac-batch\.mpkg\.zip)</string>
+        <string>(?P&lt;url&gt;https://s3\.amazonaws\.com/prey-releases/node-client/(?P&lt;version&gt;.*?)/\.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
@@ -36,9 +36,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%/%zip%</string>
+                <string>%url%</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Still not sure, but this seems closer

The actual URL:   https://s3.amazonaws.com/prey-releases/node-client/1.3.8/prey-mac-1.3.8-x64.pkg
(?P&lt;url&gt;https://s3\.amazonaws\.com/prey-releases/node-client/(?P&lt;version&gt;.*?)/\.pkg)