### PR TITLE
fix URL, add CodeSigVerification

### DIFF
--- a/Box/BoxSync.download.recipe
+++ b/Box/BoxSync.download.recipe
@@ -2,43 +2,61 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest version of Box Sync.</string>
-    <key>Identifier</key>
-    <string>com.github.hansen-m.download.boxsync</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>Box Sync</string>
-        <key>DOWNLOAD_URL</key>
-        <string>http://box.com/sync4mac</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads the latest version of Box Sync.</string>
+	<key>Identifier</key>
+	<string>com.github.hansen-m.download.boxsync</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Box Sync</string>
+		<key>URL</key>
+		<string>http://sites.box.com/sync4</string>
+		<key>USER_AGENT</key>
+		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/600.8.9 (KHTML, like Gecko) Version/8.0.8 Safari/600.8.9</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%URL%</string>
+				<!-- e.g. https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg-->
+				<key>re_pattern</key>
+				<string>(https://\w+\.\w+\.\w+/box-installers/sync/Sync\+4\+External/Box%20Sync%20Installer.dmg)</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%match%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Box Sync.app</string>
+				<key>requirement</key>
+				<string>identifier "com.box.sync" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = M683GB7CPW</string>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
New download URL(old is still live, serving... month old version at this point). My regex smooths over possible cdn-related changes, even thought they use that same URL 3 times at this (also new) help doc: http://community.box.com/t5/Box-Sync/How-Do-I-Install-or-Uninstall-Box-Sync-4-0/ta-p/85
ಠ_ಠ