### PR TITLE
Update Greenshot-Win.download.recipe

### DIFF
--- a/Greenshot/Greenshot-Win.download.recipe
+++ b/Greenshot/Greenshot-Win.download.recipe
@@ -50,7 +50,7 @@
                 <key>output_var_name</key>
                 <string>version</string>
                 <key>bes_relevance</key>
-                <string>if ("1.2.6.12" contains "-RELEASE") then (preceding text of first "-RELEASE" of "%version%" as version) else "%version%" as version</string>
+                <string>if ("%version%" contains "-RELEASE") then (preceding text of first "-RELEASE" of "%version%" as version) else "%version%" as version</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
I think the version was mistakenly hard coded in this part. I updated it to be a reference instead, which should be correct. 

I don't use this at the moment, so I have no clue.