### PR TITLE
Update Greenshot-Win.download.recipe

### DIFF
--- a/Greenshot/Greenshot-Win.download.recipe
+++ b/Greenshot/Greenshot-Win.download.recipe
@@ -50,7 +50,7 @@
                 <key>output_var_name</key>
                 <string>version</string>
                 <key>bes_relevance</key>
-                <string>if ("%version%" contains "-RELEASE") then (preceding text of first "-RELEASE" of "%version%" as version) else "%version%" as version</string>
+                <string>(it as version) of (preceding text of first "-RELEASE" of "%version%" | "%version%")</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Refactored the relevance for no reason what so ever. This should be equivalent to the previous relevance. 

The use of the | (bar) character allows for a different way to do something like IF THEN, but it does require the use of singular relevance, which I normally avoid in most cases. It makes sense in this case. See this related example:  https://bigfix.me/relevance/details/2999196

I did not test this at all, and it provides very little value, so feel free to reject the merge if you don't feel like testing it.