### PR TITLE
BESRelevanceProvider shared processor updates

### DIFF
--- a/Adobe/AdobeAIR-Win.download.recipe
+++ b/Adobe/AdobeAIR-Win.download.recipe
@@ -52,7 +52,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>

--- a/Adobe/AdobeReader-Win.download.recipe
+++ b/Adobe/AdobeReader-Win.download.recipe
@@ -37,7 +37,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>
@@ -50,7 +50,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>

--- a/Apple/iTunes-Win.download.recipe
+++ b/Apple/iTunes-Win.download.recipe
@@ -66,7 +66,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>

--- a/Skype/Skype-Win.download.recipe
+++ b/Skype/Skype-Win.download.recipe
@@ -52,7 +52,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>
@@ -65,7 +65,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>BESRelevanceProvider</string>
+            <string>com.github.hansen-m.SharedProcessors/BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>bes_filepath</key>


### PR DESCRIPTION
Updated BESRelevanceProvider to use shared processor on four download recipes.