### PR TITLE
Fix PyCharm CodeSignatureVerifier

### DIFF
--- a/PyCharm/PyCharm.download.recipe
+++ b/PyCharm/PyCharm.download.recipe
@@ -51,7 +51,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/PyCharm CE.app</string>
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>


### PR DESCRIPTION
The Application name is "PyCharm CE" vs "PyCharm Community Edition" so the environment variable will not work.