### PR TITLE
Code sig ver note for Inkscape

### DIFF
--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Inkscape.</string>
+    <string>Downloads the latest version of Inkscape.
+    Note: Code signature verification for Inkscape cannot be done at this time.</string>
     <key>Identifier</key>
     <string>com.github.hansen-m.download.Inkscape</string>
     <key>Input</key>


### PR DESCRIPTION
Added note about there being no way to do code signature verification for the Inkscape download recipe.
```
codesign --display -r- --deep -v /Volumes/Inkscape/Inkscape.app 
/Volumes/Inkscape/Inkscape.app: code object is not signed at all
```