### PR TITLE
Update search pattern for 3 digit version

### DIFF
--- a/Oracle/OracleJava8JDK.download.recipe
+++ b/Oracle/OracleJava8JDK.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk/.*?/jdk-8u[0-9]?[0-9]?-macosx-x64.dmg)</string>
+        <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk/.*?/jdk-8u\d*-macosx-x64.dmg)</string>
         <key>ORACLE_LICENSE_COOKIE</key>
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>


### PR DESCRIPTION
Overnight, our build of OracleJava8JDK failed saying:

    Error in local.munki.OracleJava8JDK: Processor:
        URLTextSearcher: Error: No match found on URL:

Checking the page shows that there has been a new release with
filename:

     jdk-8u101-macosx-x64.dmg

which didn't match the search pattern:

     jdk-8u[0-9]?[0-9]?-macosx-x64.dmg

This patch changes the search pattern to match:

    jdk-8u\d*-macosx-x64.dmg

rather than a specfic number of digits; an alternative is:

    jdk-8u[0-9]*-macosx-x64.dmg

or following the style of the original:

    jdk-8u[0-9]?[0-9]?[0-9]?-macosx-x64.dmg

I prefer the former, but YMMV.