### PR TITLE
Fix Mega.download not downloading latest version

### DIFF
--- a/MegaSoftware/Mega.download.recipe
+++ b/MegaSoftware/Mega.download.recipe
@@ -11,9 +11,9 @@
         <key>NAME</key>
         <string>Mega</string>
         <key>SEARCH_URL</key>
-        <string>http://www.megasoftware.net/history</string>
+        <string>http://www.megasoftware.net/releases/?C=M;O=D</string>
         <key>SEARCH_PATTERN</key>
-        <string>\) MEGA(?P&lt;version&gt;[0-9.]+) build (?P&lt;build&gt;[0-9]+)</string>
+        <string>MEGA(?P&lt;version&gt;[0-9\.]+)_mac32_setup\.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
@@ -38,7 +38,7 @@
                 <key>url</key>
                 <string>http://www.megasoftware.net/releases/MEGA%version%_mac32_setup.dmg</string>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>MEGA%version%_mac32_setup.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The latest version of MEGA is 7.0.18. Currently the download recipe is using http://www.megasoftware.net/history to determine which version to download, but the most recent version shown on the page is 7.0.14.

I updated the recipe to check the releases page, sorted by most recently modified.

I also reformatted the line that renames the DMG to Mega.dmg to match the filename on the server to prevent conflicts when downloading multiple versions. Let me know if you want it added back in.

This was the best I could come up with without using a custom processor as the site requires you to store some cookies and POST to two separate pages to actually get the latest version.

```
$ autopkg run Mega.download.recipe -v
Processing Mega.download.recipe...
URLTextSearcher
URLTextSearcher: Found matching text (version): 7.0.18
URLTextSearcher: Found matching text (match): 7.0.18
URLDownloader
URLDownloader: Storing new Last-Modified header: Sat, 18 Jun 2016 18:03:29 GMT
URLDownloader: Storing new ETag header: "8d648e6-5359149dc7119"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/downloads/MEGA7.0.18_mac32_setup.dmg
EndOfCheckPhase
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/receipts/Mega.download-receipt-20160813-133429.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/downloads/MEGA7.0.18_mac32_setup.dmg
```