### PR TITLE
CHECK_FILESIZE_ONLY

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -41,7 +41,7 @@
                 <key>url</key>
                 <string>%url%</string>
                 <key>filename</key>
--               <string>%NAME%.tar.bz2</string>
+                <string>%NAME%.tar.bz2</string>
             </dict>
         </dict>
         <dict>

--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -35,10 +35,13 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+            	<!-- Due to the use of mirrors, the ETag and Modified Dates cannot be used -->
+          		<key>CHECK_FILESIZE_ONLY</key>
+          		<true/>
                 <key>url</key>
                 <string>%url%</string>
                 <key>filename</key>
-                <string>%NAME%.tar.bz2</string>
+-               <string>%NAME%.tar.bz2</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Due to the use of sourceforge mirrors, the ETag and Modified Dates cannot be used