### PR TITLE
[Anaconda] Add ability to choose version

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -11,13 +11,11 @@
         <key>NAME</key>
         <string>Anaconda</string>
         <key>PYTHON_MAJOR_VERSION</key>
-        <string>3</string>
-        <key>PKG_NAME</key>
-        <string>%NAME%%PYTHON_MAJOR_VERSION%</string>
+        <string>2</string>
         <key>SEARCH_URL</key>
         <string>https://www.continuum.io/downloads#osx</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/%PKG_NAME%-(?P&lt;ANACONDA_VERSION&gt;[0-9.]+)-MacOSX-x86_64\.pkg)</string>
+        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -53,7 +51,7 @@
                 <key>url</key>
                 <string>%url%</string>
                 <key>filename</key>
-                <string>%PKG_NAME%.pkg</string>
+                <string>%NAME%%PYTHON_MAJOR_VERSION%-%version%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -10,12 +10,14 @@
     <dict>
         <key>NAME</key>
         <string>Anaconda</string>
+        <key>PYTHON_MAJOR_VERSION</key>
+        <string>3</string>
+        <key>PKG_NAME</key>
+        <string>%NAME%%PYTHON_MAJOR_VERSION%</string>
         <key>SEARCH_URL</key>
-        <string>https://continuum.io/downloads</string>
+        <string>https://www.continuum.io/downloads#osx</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/Anaconda2-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.pkg)</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/%PKG_NAME%-(?P&lt;ANACONDA_VERSION&gt;[0-9.]+)-MacOSX-x86_64\.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -26,11 +28,17 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
+                <key>url</key>
+                <string>%SEARCH_URL%</string>
+                <key>re_pattern</key>
+                <string>Python (?P&lt;PYTHON_VERSION&gt;%PYTHON_MAJOR_VERSION%\.\d) version</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
                 <key>url</key>
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
@@ -44,13 +52,8 @@
             <dict>
                 <key>url</key>
                 <string>%url%</string>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
                 <key>filename</key>
-                <string>%NAME%.pkg</string>
+                <string>%PKG_NAME%.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
There is a 2.7 version of Anaconda and (currently) a 3.5 version of Anaconda. The packages provided by Anaconda are named using the Python major version only, i.e., Anaconda2 and Anaconda3. These versions just set the Python version used for the default environment.

I added `PYTHON_MAJOR_VERSION` so you can set whether you want Anaconda2 or Anaconda3. I set the default to 3 but I'd be glad to switch it to 2 if you'd prefer.

I was having trouble setting `NAME` as `Anaconda%PYTHON_MAJOR_VERSION%` as it wouldn't expand the major version variable, so I added the `PKG_NAME` variable to keep from typing `%NAME%%PYTHON_MAJOR_VERSION%` repeatedly. 

I also got rid of the user agent since they now use an anchor for selecting which OS's downloads you want to view.

I added `PYTHON_VERSION` (which grabs the full Python version) and `ANACONDA_VERSION` so they could be used in later on, if needed.

```
$ autopkg run Anaconda.download.recipe -v
Processing Anaconda.download.recipe...
WARNING: Anaconda.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (PYTHON_VERSION): 3.5
URLTextSearcher: Found matching text (match): 3.5
URLTextSearcher
URLTextSearcher: Found matching text (url): https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg
URLTextSearcher: Found matching text (match): https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg
URLTextSearcher: Found matching text (ANACONDA_VERSION): 4.2.0
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 18 Oct 2016 00:33:47 GMT
URLDownloader: Storing new ETag header: "58056deb-19711c48"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Anaconda3.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: CONTINUUM ANALYTICS INC (Z5788K4JT7)
CodeSignatureVerifier:        SHA1 fingerprint: 88 57 F2 81 D2 DC 1A 7E F0 FA F5 2C A0 B3 86 80 D1 70 BA C0
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/receipts/Anaconda.download-receipt-20170104-154430.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3.pkg
```
