### PR TITLE
[SAOImageDS9] Update filenames to facilitate munki recipes

### DIFF
--- a/Astronomy/SAOImageDS9-app.download.recipe
+++ b/Astronomy/SAOImageDS9-app.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>SAOImage DS9</string>
+        <string>SAOImageDS9-app</string>
         <key>SAO_OS_KEY</key>
         <string>macosxmavericks</string>
         <key>SEARCH_URL</key>
@@ -38,7 +38,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%/%SAO_OS_KEY%/%dmg%</string>
                 <key>filename</key>
-                <string>SAOImage_DS9.dmg</string>
+                <string>SAOImageDS9-%SAO_OS_KEY%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Astronomy/SAOImageDS9.download.recipe
+++ b/Astronomy/SAOImageDS9.download.recipe
@@ -38,7 +38,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%/%SAO_OS_KEY%/%tar_gz_file%</string>
                 <key>filename</key>
-                <string>%NAME%.tar.gz</string>
+                <string>%NAME%-%SAO_OS_KEY%.tar.gz</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
I'm planning on creating munki recipes but would like the filenames to be different for each OS release so I don't end up with 4 `SAOImageDS9_[1-4].dmg` files. This PR would allow the filename to match up to the OS for each release.