### PR TITLE
Add installer type option for anaconda

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Anaconda Python.</string>
+    <string>Downloads the latest version of Anaconda Python.
+Different installer types are available. Use INSTALLER_TYPE
+to chose between 'sh' or 'pkg'.</string>
     <key>Identifier</key>
     <string>com.github.hansen-m.download.Anaconda</string>
     <key>Input</key>
     <dict>
+        <key>INSTALLER_TYPE</key>
+        <string>sh</string>
         <key>NAME</key>
         <string>Anaconda</string>
         <key>PYTHON_MAJOR_VERSION</key>
@@ -15,7 +19,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.continuum.io/downloads#osx</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.sh)</string>
+        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -51,7 +55,7 @@
                 <key>url</key>
                 <string>%url%</string>
                 <key>filename</key>
-                <string>%NAME%%PYTHON_MAJOR_VERSION%-%version%.sh</string>
+                <string>%NAME%%PYTHON_MAJOR_VERSION%-%version%.%INSTALLER_TYPE%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
I need the `.pkg` installer to import into munki.

This pull requests adds the option to specify both the `sh` as well as the `pkg` installers provided on the anaconda website. The `sh` option is chosen as a default.