### PR TITLE
Update Zoom recipe identifier

### DIFF
--- a/Zoom/Zoom.download.recipe
+++ b/Zoom/Zoom.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Zoom.</string>
     <key>Identifier</key>
-    <string>com.github.hansen-m.download.zoom</string>
+    <string>com.github.hansen-m.download.zoomus</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
Currently, if Zoom happens to be installed on the machine running autopkg, it will see the folder in the cache as an actual Zoom file because it ends in .zoom.  Would like to avoid having to right click and select "Show Package Contents" to see the contents.

![screen shot 2018-02-28 at 4 20 25 pm](https://user-images.githubusercontent.com/11789931/36813687-606d0f24-1ca3-11e8-9145-bec7f1c0dff7.png)
