### PR TITLE
[SAOImageDS9] Update download recipes

### DIFF
--- a/Astronomy/SAOImageDS9-app.download.recipe
+++ b/Astronomy/SAOImageDS9-app.download.recipe
@@ -10,8 +10,12 @@
     <dict>
         <key>NAME</key>
         <string>SAOImageDS9-app</string>
+        <!-- other values for SAO_OS_KEY include macoshighsierra, macosxelcapitan -->
         <key>SAO_OS_KEY</key>
-        <string>macosxmavericks</string>
+        <string>macossierra</string>
+        <!-- leave SAO_REQUESTED_VERSION blank to pull the latest version -->
+        <key>SAO_REQUESTED_VERSION</key>
+        <string></string>
         <key>SEARCH_URL</key>
         <string>http://ds9.si.edu/download</string>
     </dict>
@@ -27,7 +31,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%/%SAO_OS_KEY%/?C=M;O=D</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;dmg&gt;SAOImage\%20DS9\%20(?P&lt;version&gt;.*?)\.dmg)</string>
+                <string>(?P&lt;dmg&gt;SAOImage(\%20)?DS9\%20(?P&lt;version&gt;%SAO_REQUESTED_VERSION%.*?)\.dmg)</string>
             </dict>
         </dict>
         <dict>

--- a/Astronomy/SAOImageDS9.download.recipe
+++ b/Astronomy/SAOImageDS9.download.recipe
@@ -10,8 +10,12 @@
     <dict>
         <key>NAME</key>
         <string>SAOImageDS9</string>
+        <!-- other values for SAO_OS_KEY include darwinhighsierra, darwinelcapitan -->
         <key>SAO_OS_KEY</key>
-        <string>darwinmavericks</string>
+        <string>darwinsierra</string>
+        <!-- leave SAO_REQUESTED_VERSION blank to pull the latest version -->
+        <key>SAO_REQUESTED_VERSION</key>
+        <string></string>
         <key>SEARCH_URL</key>
         <string>http://ds9.si.edu/download</string>
     </dict>
@@ -27,7 +31,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%/%SAO_OS_KEY%/?C=M;O=D</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;tar_gz_file&gt;ds9\.%SAO_OS_KEY%\.(?P&lt;version&gt;.*?)\.tar.gz)</string>
+                <string>(?P&lt;tar_gz_file&gt;ds9\.%SAO_OS_KEY%\.(?P&lt;version&gt;%SAO_REQUESTED_VERSION%.*?)\.tar.gz)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
I updated the `SAO_OS_KEY`s to point to Sierra and added a note on what other values might be. 

I added `SAO_REQUESTED_VERSION` so you could pick whether you want 7.5 or 7.6. It defaults to pulling the latest version.

The developer is changing the name from **SAOImage DS9** to **SAOImageDS9**, so I updated the `re_pattern` to make that space optional.

7.5 is code signed but 7.6 isn't so I didn't add CodSignatureVerification to the recipe. And, by the looks of it, 7.6 isn't going to be code signed any time soon.

From the developer
>Starting with High Sierra I have found it impossible to correctly sign my apps. It really messes up High Sierra, or I should say High Sierra really messes with DS9. In particular the problem is with GateKeeper. The previous method of signing no longer works. (More and more, its the ‘Apple’ way or the highway as DS9 is not build with Xcode). The best compromise is to not sign it and let the installation process take care of it. The alternative was to have the user disable Gatekeeper, install DS9, then re-enable. You can track the conversation on twitter @SAOImageDS9.