### PR TITLE
Update BoxSync.download.recipe

### DIFF
--- a/Box/BoxSync.download.recipe
+++ b/Box/BoxSync.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Box Sync</string>
 		<key>URL</key>
-		<string>https://sites.box.com/sync4</string>
+		<string>https://community.box.com/t5/Using-Box-Sync/Installing-Box-Sync/ta-p/85</string>
 		<key>USER_AGENT</key>
 		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/600.8.9 (KHTML, like Gecko) Version/8.0.8 Safari/600.8.9</string>
 	</dict>


### PR DESCRIPTION
Changed URL, as it's no longer available from https://sites.box.com/sync4. Just a note though, this is linked through a community forum, so may disappear at some point. Are Box deprecating Sync in favour of Drive?