### PR TITLE
Using deployment package for Zoom

### DIFF
--- a/Zoom/Zoom.download.recipe
+++ b/Zoom/Zoom.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Zoom</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://zoom.us/client/latest/zoomusInstaller.pkg</string>
+        <string>https://zoom.us/client/latest/ZoomInstallerIT.pkg</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>


### PR DESCRIPTION
Zoom provide a specific deployment package to be used by IT doing mass deployment.

The current URL is the one targeted the end user package (who include a lot of nasty things for the install script).

This change is needed to have a proper deployment package downloaded by autopkg.