### PR TITLE
Changes to the copier processor

### DIFF
--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -46,9 +46,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/GIMP.app</string>
+                <string>%pathname%/Gimp*.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/GIMP.app</string>
+                <string>%pkgroot%/Applications/%NAME%.app</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This fixes the Gimp recipe. It also sets up the destination path with the %NAME% variable, that's set in the recipe input.