### PR TITLE
Adding OracleJava11JDK.download recipe

### DIFF
--- a/Oracle/OracleJava11JDK.download.recipe
+++ b/Oracle/OracleJava11JDK.download.recipe
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest Java 11 JDK from Oracle.</string>
+    <key>Identifier</key>
+    <string>com.github.hansen-m.download.OracleJava11JDK</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>OracleJava11JDK</string>
+        <key>SEARCH_URL</key>
+        <string>https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html</string>
+        <key>SEARCH_PATTERN</key>
+        <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)</string>
+        <key>ORACLE_LICENSE_COOKIE</key>
+        <string>oraclelicense=accept-securebackup-cookie</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%SEARCH_URL%</string>
+                <key>re_pattern</key>
+                <string>%SEARCH_PATTERN%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>request_headers</key>
+                <dict>
+                        <key>Cookie</key>
+                        <string>%ORACLE_LICENSE_COOKIE%</string>
+                </dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/JDK 11*.pkg</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Oracle America, Inc. (VB5E2TV963)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Uploading an AutoPkg OracleJava11JDK.download recipe to download the Oracle Java 11 JDK