### PR TITLE
Update OracleJava11JDK.download.recipe

### DIFF
--- a/Oracle/OracleJava11JDK.download.recipe
+++ b/Oracle/OracleJava11JDK.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)</string>
+        <string>(?P&lt;url&gt;https://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)</string>
         <key>ORACLE_LICENSE_COOKIE</key>
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>


### PR DESCRIPTION
Updates the `SEARCH_PATTERN` variable from using `http` to using `https`:

From: `(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)`

To: `(?P&lt;url&gt;https://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)`