### PR TITLE
Update search pattern and url downloader https

### DIFF
--- a/Oracle/OracleJava11JDK.download.recipe
+++ b/Oracle/OracleJava11JDK.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https://download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)</string>
+        <string>(?P&lt;url&gt;download.oracle.com/otn-pub/java/jdk.*?/jdk-11\.[0-9\.]+_osx-x64_bin\.dmg)</string>
         <key>ORACLE_LICENSE_COOKIE</key>
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%url%</string>
+                <string>https://%url%</string>
                 <key>request_headers</key>
                 <dict>
                         <key>Cookie</key>


### PR DESCRIPTION
Update search pattern to match actual one and force Url downloader to use https.
Oracle website uses http, https download is working.