### PR TITLE
Updated the Search Pattern for Anaconda.download.recipe

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -19,7 +19,7 @@ to chose between 'sh' or 'pkg'.</string>
         <key>SEARCH_URL</key>
         <string>https://www.anaconda.com/download/#macos</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.continuum\.io/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
+        <string>(?P&lt;url&gt;https\://repo\.(anaconda|continuum)\.(com|io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
....Not sure what they're doing, but the download URL on the page keeps changing between:
https://repo.anaconda.com[...]
https://repo.continuum.io[...]

This update should support whichever flavor of the day, they want to use...