### PR TITLE
Update GIMP.pkg.recipe

### DIFF
--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -46,7 +46,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/Gimp*.app</string>
+                <string>%pathname%/*.app</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/Applications/%NAME%.app</string>
             </dict>


### PR DESCRIPTION
Looks like the app filename has changed from Gimp-<version> to GIMP-<version> ... I've changed the PKG recipe to just look for *.app within the DMG as this should pick up either.

Hope that's ok?