### PR TITLE
Remove byte order marker from xml file

### DIFF
--- a/SharedProcessors/lessmsi/LICENSE
+++ b/SharedProcessors/lessmsi/LICENSE
@@ -1,14 +1,14 @@
-﻿// Permission is hereby granted, free of charge, to any person obtaining
+// Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
 // without limitation the rights to use, copy, modify, merge, publish,
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND


### PR DESCRIPTION
The BOM is frequently added by text editors on Windows (e.g. Notepad) and is unnecessary.

https://www.w3.org/International/questions/qa-byte-order-mark