### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Amazon/Kindle.pkg.recipe
+++ b/Amazon/Kindle.pkg.recipe
@@ -46,9 +46,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Kindle.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Kindle.app</string>
             </dict>
         </dict>
         <dict>

--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -48,7 +48,7 @@
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/GIMP.app</string>
             </dict>
         </dict>
         <dict>

--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -53,7 +53,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/RStudio.app</string>
                 <key>requirement</key>
                 <string>identifier "org.rstudio.RStudio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FYF2F5GFX4</string>
             </dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.