### PR TITLE
Rename to distinguish Unity Hub from Unity Editor

### DIFF
--- a/Unity3D/UnityHub.download.recipe
+++ b/Unity3D/UnityHub.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Unity 3D.</string>
+    <string>Downloads the latest version of Unity Hub.</string>
     <key>Identifier</key>
-    <string>com.github.hansen-m.download.Unity3D</string>
+    <string>com.github.hansen-m.download.UnityHub</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Unity3D</string>
+        <string>UnityHub</string>
         <key>DOWNLOAD_URL</key>
         <string>https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg</string>
     </dict>
@@ -25,7 +25,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
-                <string>Unity3D.dmg</string>
+                <string>UnityHub.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Unity3D.dmg/Unity Hub.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/UnityHub.dmg/Unity Hub.app</string>
                 <key>requirement</key>
                 <string>identifier "com.unity3d.unityhub" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = BVPN9UFA9B</string>
             </dict>


### PR DESCRIPTION
Since Unity Hub and Unity Editor are now two different applications, it would be good to specify this recipe is downloading the Hub application.