### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Fetch/FetchVersionFixer.py
+++ b/Fetch/FetchVersionFixer.py
@@ -9,10 +9,10 @@
 # contains a Unicode Zero-width space that causes us lots of problems.
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["FetchVersionFixer"]
 

--- a/Fetch/FetchVersionFixer.py
+++ b/Fetch/FetchVersionFixer.py
@@ -35,7 +35,7 @@ class FetchVersionFixer(Processor):
     
     def main(self):
         ascii_version = self.env.get('version').encode("ascii", "ignore")
-        rematch_version = re.search('[ -~][0-9.]+', ascii_version)
+        rematch_version = re.search(r'[ -~][0-9.]+', ascii_version)
         
         self.env["version"] = rematch_version.group(0)
         self.output("Cleaned version string %s" % self.env["version"])

--- a/Fetch/FetchVersionFixer.py
+++ b/Fetch/FetchVersionFixer.py
@@ -8,6 +8,7 @@
 # As of version Fetch 5.7.3 the Contents/Info.plist CFBundleVersion key 
 # contains a Unicode Zero-width space that causes us lots of problems.
 
+from __future__ import absolute_import
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/BESRelevanceProvider.py
+++ b/SharedProcessors/BESRelevanceProvider.py
@@ -12,8 +12,9 @@ AutoPkg Processor for retreiving relevance data for tasks.
 """
 
 from __future__ import absolute_import
-import os
+
 import hashlib
+import os
 import subprocess
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/BESRelevanceProvider.py
+++ b/SharedProcessors/BESRelevanceProvider.py
@@ -117,7 +117,7 @@ class BESRelevanceProvider(Processor):
 
             relevance_result = self.eval_relevance(bes_relevance)
 
-            if relevance_result != None:
+            if relevance_result is not None:
                 self.env[output_var_name] = relevance_result
             elif output_var_name not in self.env:
                 self.env[output_var_name] = None

--- a/SharedProcessors/BESRelevanceProvider.py
+++ b/SharedProcessors/BESRelevanceProvider.py
@@ -81,7 +81,7 @@ class BESRelevanceProvider(Processor):
                 return None
             else:
                 return output.get('A', None)
-        except Exception as error:
+        except BaseException as error:
             self.output("QnA Error: (%s) -- %s" % (QNA, error))
             return None
 

--- a/SharedProcessors/BESRelevanceProvider.py
+++ b/SharedProcessors/BESRelevanceProvider.py
@@ -11,6 +11,7 @@ Created by Matt Hansen (mah60@psu.edu) on 2014-02-19.
 AutoPkg Processor for retreiving relevance data for tasks.
 """
 
+from __future__ import absolute_import
 import os
 import hashlib
 import subprocess
@@ -80,7 +81,7 @@ class BESRelevanceProvider(Processor):
                 return None
             else:
                 return output.get('A', None)
-        except Exception, error:
+        except Exception as error:
             self.output("QnA Error: (%s) -- %s" % (QNA, error))
             return None
 
@@ -95,10 +96,10 @@ class BESRelevanceProvider(Processor):
 
         if bes_filepath and os.path.isfile(bes_filepath):
 
-            self.env['bes_sha1'] = hashlib.sha1(file(
+            self.env['bes_sha1'] = hashlib.sha1(open(
                 bes_filepath).read()).hexdigest()
             self.env['bes_size'] = str(os.path.getsize(bes_filepath))
-            self.env['bes_sha256'] = hashlib.sha256(file(
+            self.env['bes_sha256'] = hashlib.sha256(open(
                 bes_filepath).read()).hexdigest()
             self.env['bes_sha1_short'] = str(self.env.get("bes_sha1"))[-5:]
 

--- a/SharedProcessors/ExeVersionExtractor.py
+++ b/SharedProcessors/ExeVersionExtractor.py
@@ -7,6 +7,8 @@
 #
 # Extracts version info from .exe file using the 7z utility.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -64,7 +66,7 @@ class ExeVersionExtractor(Processor):
         archiveVersion = ""
         for line in Output.split("\n"):
             if verbosity > 2:
-                print line
+                print(line)
             if "ProductVersion:" in line:
                 archiveVersion = line.split()[-1]
                 continue

--- a/SharedProcessors/ExeVersionExtractor.py
+++ b/SharedProcessors/ExeVersionExtractor.py
@@ -7,14 +7,11 @@
 #
 # Extracts version info from .exe file using the 7z utility.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import os
-import sys
+from __future__ import absolute_import, print_function
+
 import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["ExeVersionExtractor"]
 

--- a/SharedProcessors/GoogleChromeWinVersioner.py
+++ b/SharedProcessors/GoogleChromeWinVersioner.py
@@ -7,6 +7,7 @@
 # Based on WinInstallerExtractor
 
 
+from __future__ import absolute_import
 import os
 import sys
 import subprocess

--- a/SharedProcessors/GoogleChromeWinVersioner.py
+++ b/SharedProcessors/GoogleChromeWinVersioner.py
@@ -8,13 +8,11 @@
 
 
 from __future__ import absolute_import
-import os
-import sys
-import subprocess
+
 import re
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["GoogleChromeWinVersioner"]
 

--- a/SharedProcessors/HachoirMetaDataProvider.py
+++ b/SharedProcessors/HachoirMetaDataProvider.py
@@ -10,11 +10,13 @@
 # Retreives file metadata using the Hachoir metadata library.
 # Requires https://bitbucket.org/haypo/hachoir/wiki/hachoir-metadata
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import os
-import sys
 import string
+import sys
+
+from autopkglib import Processor, ProcessorError
 
 try:
     import hachoir_core
@@ -32,7 +34,6 @@ except ImportError:
     """)
     sys.exit(1)
 
-from autopkglib import Processor, ProcessorError
 
 
 __all__ = ["HachoirMetaDataProvider"]

--- a/SharedProcessors/HachoirMetaDataProvider.py
+++ b/SharedProcessors/HachoirMetaDataProvider.py
@@ -10,6 +10,8 @@
 # Retreives file metadata using the Hachoir metadata library.
 # Requires https://bitbucket.org/haypo/hachoir/wiki/hachoir-metadata
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import string
@@ -20,14 +22,14 @@ try:
     import hachoir_metadata
     import hachoir_parser
 except ImportError:
-    print """
+    print("""
     Hachoir Modules not installed!
 
     Install using: 
         `pip install hachoir_core`
         `pip install hachoir_metadata`
         `pip install hachoir_parser`
-    """
+    """)
     sys.exit(1)
 
 from autopkglib import Processor, ProcessorError
@@ -75,7 +77,7 @@ class HachoirMetaDataProvider(Processor):
 
         try:
             metadata = hachoir_metadata.extractMetadata(parser)
-        except HachoirError, err:
+        except HachoirError as err:
             self.output("Metadata extraction error: %s" % unicode(err))
             sys.exit(1)
             

--- a/SharedProcessors/MSIVersionProvider.py
+++ b/SharedProcessors/MSIVersionProvider.py
@@ -8,6 +8,7 @@
 # Retreives the version of a .msi file using the lessmsi utility via Wine.
 # Requires installation of Wine, and availablility of 'wine' in PATH
 
+from __future__ import absolute_import
 import os
 import sys
 import subprocess

--- a/SharedProcessors/MSIVersionProvider.py
+++ b/SharedProcessors/MSIVersionProvider.py
@@ -9,12 +9,12 @@
 # Requires installation of Wine, and availablility of 'wine' in PATH
 
 from __future__ import absolute_import
+
 import os
-import sys
 import subprocess
+import sys
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSIVersionProvider"]
 

--- a/SharedProcessors/WinInstallerExtractor.py
+++ b/SharedProcessors/WinInstallerExtractor.py
@@ -6,6 +6,7 @@
 #
 # Extracts the .exe or .msi file using the 7z utility.
 
+from __future__ import absolute_import
 import os
 import sys
 import subprocess

--- a/SharedProcessors/WinInstallerExtractor.py
+++ b/SharedProcessors/WinInstallerExtractor.py
@@ -7,12 +7,10 @@
 # Extracts the .exe or .msi file using the 7z utility.
 
 from __future__ import absolute_import
-import os
-import sys
+
 import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["WinInstallerExtractor"]
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including a few things in HachoirMetaDataProvider), but this should catch the low-hanging fruit right now.