### PR TITLE
Alternate URLTextSearcher method, hard-coded

### DIFF
--- a/VueScan/VueScan.download.recipe
+++ b/VueScan/VueScan.download.recipe
@@ -12,10 +12,6 @@
         <string>VueScan</string>
         <key>ARCH</key>
         <string>64</string>
-        <key>SEARCH_URL</key>
-        <string>https://www.hamrick.com/vuescan/vuescan.htm</string>
-        <key>SEARCH_PATTERN</key>
-        <string>VueScan (?P&lt;vers&gt;[\d]).(?P&lt;vers2&gt;[\d]+)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -27,9 +23,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%</string>
+                <string>https://www.hamrick.com/alternate-versions.html</string>
                 <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
+                <string>href="files/(vuex%ARCH%[\d]+\.dmg)"</string>
             </dict>
         </dict>
         <dict>
@@ -38,9 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://d2bwyyzfw77fhf.cloudfront.net/vuex%ARCH%%vers%%vers2%.dmg</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>https://d2bwyyzfw77fhf.cloudfront.net/%match%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR makes 4 related changes. In order of appearance: 1. Eliminates SEARCH_URL and SEARCH_PATTERN variables in favour of hard-coding those strings into the recipe (this caught me on the previous update, where the recipe broke when I had the old search patterns in my override). 2. Uses the historical downloads page (which includes the most current version) as the source for URLTextSearcher. 3. Changes the re_pattern to capture the full filename (using parenthesis) to the default variable "match". 4. Eliminates renaming the download, since no child recipe is dependent on having it named %NAME%.dmg; the existing name actually provides more info about the download. If you want to reject this for your repo (since the current version still works if the user recreates their override), let me know and I will make this available in my own repo instead.