### PR TITLE
Use core DeprecationWarning processor instead of shared processor

### DIFF
--- a/Oracle/OracleJava10JDK.download.recipe
+++ b/Oracle/OracleJava10JDK.download.recipe
@@ -18,12 +18,12 @@
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava11JDK.download.recipe
+++ b/Oracle/OracleJava11JDK.download.recipe
@@ -18,12 +18,12 @@
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava7JDK.download.recipe
+++ b/Oracle/OracleJava7JDK.download.recipe
@@ -18,12 +18,12 @@
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava8-Win.download.recipe
+++ b/Oracle/OracleJava8-Win.download.recipe
@@ -20,12 +20,12 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
         <string>Java8JRE</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava8JDK.download.recipe
+++ b/Oracle/OracleJava8JDK.download.recipe
@@ -18,12 +18,12 @@
         <string>oraclelicense=accept-securebackup-cookie; domain=.oracle.com; path=/; expires=Tue, 23 Jul 2019;</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava8x64-Win.download.recipe
+++ b/Oracle/OracleJava8x64-Win.download.recipe
@@ -20,12 +20,12 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
         <string>Java8JRE</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Oracle/OracleJava9JDK.download.recipe
+++ b/Oracle/OracleJava9JDK.download.recipe
@@ -18,12 +18,12 @@
         <string>oraclelicense=accept-securebackup-cookie</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>


### PR DESCRIPTION
This change will no longer require adding the gregneagle-recipes repo when running these recipes and displaying the deprecation message.