### PR TITLE
Update Kindle.download.recipe

### DIFF
--- a/Amazon/Kindle.download.recipe
+++ b/Amazon/Kindle.download.recipe
@@ -47,7 +47,7 @@
                 <key>input_path</key>
                 <string>%pathname%/Kindle.app</string>
                 <key>requirement</key>
-                <string>identifier "com.amazon.Kindle" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"</string>
+                <string>identifier "com.amazon.kindle" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
identifier changes from uppercase to lowercase.
```
CodeSignatureVerifier
{'Input': {'input_path': u'/Users/ladmin/Library/AutoPkg/Cache/com.github.hansen-m.download.Kindle/downloads/Kindle.dmg/Kindle.app',
           'requirement': u'identifier "com.amazon.Kindle" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"'}}
CodeSignatureVerifier: Mounted disk image /Users/ladmin/Library/AutoPkg/Cache/com.github.hansen-m.download.Kindle/downloads/Kindle.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.d1R7FA/Kindle.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.d1R7FA/Kindle.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
```