### PR TITLE
Download Kindle installer over HTTPS

### DIFF
--- a/Amazon/Kindle.download.recipe
+++ b/Amazon/Kindle.download.recipe
@@ -13,7 +13,7 @@
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/601.4.4 (KHTML, like Gecko) Version/9.0.3 Safari/601.4.4</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.amazon.com/kindlemacdownload/ref=klp_mac</string>
+        <string>https://www.amazon.com/kindlemacdownload/ref=klp_mac</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
Found this while running `autopkg audit` on some overrides.