### PR TITLE
Fix Amazon Music download URI

### DIFF
--- a/Amazon/AmazonMusic.download.recipe
+++ b/Amazon/AmazonMusic.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.amazon.com/gp/dmusic/desktop/downloadPlayer/</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https://[A-Za-z0-9.-]+amazon\.com/.*?/AmazonMusicInstaller\.dmg)</string>
+        <string>(?P&lt;url&gt;https://[A-Za-z0-9.-]+amazonaws\.com/.*?/AmazonMusicInstaller\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -65,7 +65,7 @@
                 <key>input_path</key>
                 <string>%pathname%/Amazon Music Installer.app</string>
                 <key>requirement</key>
-                <string>identifier "com.amazon.music" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"</string>
+                <string>identifier "com.bitrock.appinstaller" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
The installer is now hosted on S3 and uses Bitrock.