### PR TITLE
Update MEGA Recipe

### DIFF
--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -5,7 +5,7 @@
 Based on F5transkriptURLProvider.py by Tim Keller
 https://github.com/TK5-Tim/its-unibas-recipes/blob/LogitecSync/F5transkript/F5transkriptURLProvider.py
 
-The resulting link should be formatted similary: https://downloads.ccdc.cam.ac.uk/Mercury/2020.1/mercury-2020.1.0-macos-installer.dmg
+The resulting link should be formatted similary: https://www.megasoftware.net/do_force_download/MEGAX_10.1.8_installer.pkg
 """
 
 from __future__ import absolute_import, print_function
@@ -37,10 +37,10 @@ class MEGAURLProvider(URLGetter):
 		if sys.version_info.major < 3:
 			html_source = self.download(VERSION_URL)
 		else:
-			html_source = self.download(VERSION_URL).devode("utf-8")
+			html_source = self.download(VERSION_URL).decode("utf-8")
 		escaped_url = re.search(REGEX, html_source).group(1)
 		unescaped_url = HTMLParser().unescape(escaped_url)
-		SUFFIX = "{}_installer.pkg".format(unescaped_url)
+		suffix = "_installer.pkg"
 		return_url = BASE_URL + unescaped_url + suffix
 		self.env["url"] = return_url
 		print(

--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Based on F5transkriptURLProvider.py by Tim Keller
+https://github.com/TK5-Tim/its-unibas-recipes/blob/LogitecSync/F5transkript/F5transkriptURLProvider.py
+
+The resulting link should be formatted similary: https://downloads.ccdc.cam.ac.uk/Mercury/2020.1/mercury-2020.1.0-macos-installer.dmg
+"""
+
+from __future__ import absolute_import, print_function
+import re
+from autopkglib import URLGetter
+import sys
+
+try:
+	#import for Python 3
+	from html.parser import HTMLParser
+except ImportError:
+	#import for Python 2
+	from HTMLParser import HTMLParser
+
+VERSION_URL = "https://www.megasoftware.net/history"
+BASE_URL = "https://www.megasoftware.net/do_force_download/MEGAX_"
+REGEX = "(\d{2}\.\d\.\d)"
+
+
+#__all__ == ["MEGAURLProvider"]
+
+class MEGAURLProvider(URLGetter):
+	"""Provides a download URL for the latest version of MEGA"""
+	description = __doc__
+	input_variables = {}
+	output_variables = {"url": {"description:" "URL to latest version"}}
+
+	def main(self):
+		if sys.version_info.major < 3:
+			html_source = self.download(VERSION_URL)
+		else:
+			html_source = self.download(VERSION_URL).devode("utf-8")
+		escaped_url = re.search(REGEX, html_source).group(1)
+		unescaped_url = HTMLParser().unescape(escaped_url)
+		SUFFIX = "{}_installer.pkg".format(unescaped_url)
+		return_url = BASE_URL + unescaped_url + suffix
+		self.env["url"] = return_url
+		print(
+			"MEGAURLProvider: Match found is %s\n"
+			"MEGAURLProvider: Unescaped url is: %s\n"
+			"MEGAURLProvider: Suffix is: %s\n"
+			"MEGAURLProvider: Returning full url: %s "
+			% (escaped_url, unescaped_url, suffix, return_url)
+		)
+
+
+if __name__ == "__main__":
+	processor = MEGAURLProvider()
+	processor.execute_shell()

--- a/MegaSoftware/Mega.download.recipe
+++ b/MegaSoftware/Mega.download.recipe
@@ -10,21 +10,27 @@
     <dict>
         <key>NAME</key>
         <string>Mega</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://www.megasoftware.net/releases/MEGA7.0.21_mac32_setup.dmg</string>
+        <key>APP_FILENAME</key>
+        <string>MEGAXstandalone-osx-installer</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict/>
             <key>Processor</key>
-            <string>URLDownloader</string>
+            <string>MEGAURLProvider</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <key>filename</key>
+                <string>%APP_FILENAME%.pkg</string>
             </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
This pull request updates the current MEGA recipe by adding a new URLProvider processor script written in Python.
The current link in the recipe is hardcoded and only downloads a certain version 7.x.x
The new URLProvider however always downloads the newest MEGA X version that is published on the Update History page (https://www.megasoftware.net/history) by:

1. scraping the topmost version number with a regex and then
2. formatting a download URL string which is returned as the 'ur'l variable later used in Mega.download.recipe
    the download URL is of the format: https://www.megasoftware.net/do_force_download/MEGAX_x.x.x_installer.pkg
 
Changes have been made to the .download.recipe to accept this input and tests have been successful in downloading MEGAX v.10.7.0 and v.10.8.0