### PR TITLE
Add hardcoded link for v1.0.0 and comment out URLTextSearcher processors

### DIFF
--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -12,18 +12,21 @@
         <key>NAME</key>
         <string>Inkscape</string>
         <key>SEARCH_URL</key>
-        <string>https://inkscape.org/en/release/</string>
+        <string>https://inkscape.org/release/</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;\/en\/release.*dmg\/dl\/)</string>
         <key>SEARCH_PATTERN1</key>
-        <string>(/release/inkscape-(?P&lt;version&gt;[0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/1010-1015/dl/)</string>
+        <string>(/release/inkscape-([0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/1010-1015/dl/)</string>
         <key>SEARCH_PATTERN2</key>
-        <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>        
+        <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>    
+        <key>dmgurl</key>
+        <string>/gallery/item/18459/Inkscape-1.0.0.dmg</string>    
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>Process</key>
     <array>
+        <!--
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -46,6 +49,7 @@
                 <string>%SEARCH_PATTERN2%</string>
             </dict>
         </dict>
+        -->
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This is a temporary fix for the Inkscape.download.recipe which currently doesn't seem to work.

I've replaced the failing URLTextSearcher processors and I've added a hardcoded link which downloads Inkscape version 1.0.0 the newest available stable version for macOS.