### PR TITLE
Chain URLTextSearcher processors for download URL

### DIFF
--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Inkscape.
-    Note: Code signature verification for Inkscape cannot be done at this time.</string>
+    <string>Downloads the latest version of Inkscape.</string>
     <key>Identifier</key>
     <string>com.github.hansen-m.download.Inkscape</string>
     <key>Input</key>
@@ -12,30 +11,27 @@
         <key>NAME</key>
         <string>Inkscape</string>
         <key>SEARCH_URL</key>
-        <string>https://inkscape.org/release/</string>
-        <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;\/en\/release.*dmg\/dl\/)</string>
+        <string>https://inkscape.org</string>
         <key>SEARCH_PATTERN1</key>
         <string>(/release/inkscape-([0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/1010-1015/dl/)</string>
         <key>SEARCH_PATTERN2</key>
         <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>    
-        <key>dmgurl</key>
-        <string>/gallery/item/18459/Inkscape-1.0.0.dmg</string>    
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>Process</key>
     <array>
-        <!--
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%</string>
+                <string>%SEARCH_URL%/release</string>
                 <key>re_pattern</key>
                 <string>%SEARCH_PATTERN1%</string>
+                <key>result_output_var_name</key>
+                <string>release_page_match</string>
             </dict>
         </dict>
         <dict>
@@ -44,19 +40,20 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://inkscape.org%match%</string>
+                <string>%SEARCH_URL%%release_page_match%</string>
                 <key>re_pattern</key>
                 <string>%SEARCH_PATTERN2%</string>
+                <key>result_output_var_name</key>
+                <string>gallery_download_match</string>
             </dict>
         </dict>
-        -->
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://inkscape.org%dmgurl%</string>
+                <string>%SEARCH_URL%%gallery_download_match%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>


### PR DESCRIPTION
Please accept my PR to update the Inkscape recipe to search for latest release instead of a hardcoded URL. Current version only finds 1.0. when 1.0.1 is latest. Chains two URLTextSearcher processors together to get the download URL. Hopefully they don't change download page again anytime soon. 