### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Zoom/Zoom.download.recipe
+++ b/Zoom/Zoom.download.recipe
@@ -46,7 +46,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%</string>
-                <key>exepected_authority_names</key>
+                <key>expected_authority_names</key>
                     <array>
                         <string>Developer ID Installer: Zoom Video Communications, Inc.</string>
                         <string>Developer ID Certification Authority</string>


### PR DESCRIPTION
Correct argument name is `expected_authority_names`. (https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier)