### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Amazon/Kindle.pkg.recipe
+++ b/Amazon/Kindle.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Aquamacs/Aquamacs.pkg.recipe
+++ b/Aquamacs/Aquamacs.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/BESEngine/BESEngine.pkg.recipe
+++ b/BESEngine/BESEngine.pkg.recipe
@@ -143,12 +143,12 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
-                <key>version</key>
-                <string>%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%/</string>
                     <key>id</key>

--- a/BESPythonAPI/BESPythonAPI.pkg.recipe
+++ b/BESPythonAPI/BESPythonAPI.pkg.recipe
@@ -192,12 +192,12 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
-                <key>version</key>
-                <string>%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%/</string>
                     <key>id</key>

--- a/BigFix/QnA.pkg.recipe
+++ b/BigFix/QnA.pkg.recipe
@@ -130,12 +130,12 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
-                <key>version</key>
-                <string>%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%/</string>
                     <key>id</key>

--- a/Box/BoxSync.pkg.recipe
+++ b/Box/BoxSync.pkg.recipe
@@ -111,10 +111,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>BoxSync-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>BoxSync-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/PyCharm/PyCharm.pkg.recipe
+++ b/PyCharm/PyCharm.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>PyCharmCE-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>PyCharmCE-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Texmaker/Texmaker.pkg.recipe
+++ b/Texmaker/Texmaker.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
`pkgname` and `version` are [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).