### PR TITLE
Output the version found on the website

### DIFF
--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -14,52 +14,50 @@ from autopkglib import URLGetter
 import sys
 
 try:
-	#import for Python 3
-	from html.parser import HTMLParser
+    # import for Python 3
+    from html.parser import HTMLParser
 except ImportError:
-	#import for Python 2
-	from HTMLParser import HTMLParser
+    # import for Python 2
+    from HTMLParser import HTMLParser
 
 VERSION_URL = "https://www.megasoftware.net/history"
 BASE_URL = "https://www.megasoftware.net/do_force_download/MEGAX_"
 REGEX = "(\d{2}\.\d\.\d)"
 
 
-#__all__ == ["MEGAURLProvider"]
+# __all__ == ["MEGAURLProvider"]
+
 
 class MEGAURLProvider(URLGetter):
-	"""Provides a download URL for the latest version of MEGA"""
-	description = __doc__
-	input_variables = {}
-	output_variables = {
-		"url": {
-			"description": "URL to latest version"
-		},
-		"version": {
-			"description": "The latest version found"
-		}
-	}
+    """Provides a download URL for the latest version of MEGA"""
 
-	def main(self):
-		if sys.version_info.major < 3:
-			html_source = self.download(VERSION_URL)
-		else:
-			html_source = self.download(VERSION_URL).decode("utf-8")
-		escaped_url = re.search(REGEX, html_source).group(1)
-		unescaped_url = HTMLParser().unescape(escaped_url)
-		suffix = "_installer.pkg"
-		return_url = BASE_URL + unescaped_url + suffix
-		self.env["version"] = escaped_url
-		self.env["url"] = return_url
-		print(
-			"MEGAURLProvider: Match found is %s\n"
-			"MEGAURLProvider: Unescaped url is: %s\n"
-			"MEGAURLProvider: Suffix is: %s\n"
-			"MEGAURLProvider: Returning full url: %s "
-			% (escaped_url, unescaped_url, suffix, return_url)
-		)
+    description = __doc__
+    input_variables = {}
+    output_variables = {
+        "url": {"description": "URL to latest version"},
+        "version": {"description": "The latest version found"},
+    }
+
+    def main(self):
+        if sys.version_info.major < 3:
+            html_source = self.download(VERSION_URL)
+        else:
+            html_source = self.download(VERSION_URL).decode("utf-8")
+        escaped_url = re.search(REGEX, html_source).group(1)
+        unescaped_url = HTMLParser().unescape(escaped_url)
+        suffix = "_installer.pkg"
+        return_url = BASE_URL + unescaped_url + suffix
+        self.env["version"] = escaped_url
+        self.env["url"] = return_url
+        print(
+            "MEGAURLProvider: Match found is %s\n"
+            "MEGAURLProvider: Unescaped url is: %s\n"
+            "MEGAURLProvider: Suffix is: %s\n"
+            "MEGAURLProvider: Returning full url: %s "
+            % (escaped_url, unescaped_url, suffix, return_url)
+        )
 
 
 if __name__ == "__main__":
-	processor = MEGAURLProvider()
-	processor.execute_shell()
+    processor = MEGAURLProvider()
+    processor.execute_shell()

--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -31,7 +31,14 @@ class MEGAURLProvider(URLGetter):
 	"""Provides a download URL for the latest version of MEGA"""
 	description = __doc__
 	input_variables = {}
-	output_variables = {"url": {"description:" "URL to latest version"}}
+	output_variables = {
+		"url": {
+			"description": "URL to latest version"
+		},
+		"version": {
+			"description": "The latest version found"
+		}
+	}
 
 	def main(self):
 		if sys.version_info.major < 3:
@@ -42,6 +49,7 @@ class MEGAURLProvider(URLGetter):
 		unescaped_url = HTMLParser().unescape(escaped_url)
 		suffix = "_installer.pkg"
 		return_url = BASE_URL + unescaped_url + suffix
+		self.env["version"] = escaped_url
 		self.env["url"] = return_url
 		print(
 			"MEGAURLProvider: Match found is %s\n"


### PR DESCRIPTION
In an effort to help detect which version of MEGA is installed, we need to capture and pass along the latest version we found on the website for other processors to use.