### PR TITLE
Change MEGA URL provider specific to MacOS versions 

### DIFF
--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -22,7 +22,7 @@ except ImportError:
 
 VERSION_URL = "https://www.megasoftware.net/history"
 BASE_URL = "https://www.megasoftware.net/do_force_download/MEGAX_"
-REGEX = "(\d{2}\.\d\.\d)"
+REGEX = "MEGA\ X\ version\ (\d{2}\.\d\.\d).*macOS"
 
 
 # __all__ == ["MEGAURLProvider"]


### PR DESCRIPTION
Somehow Mega started to release all the macOS patches later than the Windows and Linux versions. So the version where MacOS is not specifically mentioned it is not included. It somehow downloads something for the version 10.2.5 but it is not a MacOS installer package. So I adjusted the regex to only search for macOS versions. 

Output `autopkg run -vv Mega.download.recipe`: 
```
Processing Mega.download.recipe...
WARNING: Mega.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MEGAURLProvider
{'Input': {}}
MEGAURLProvider: Match found is 10.2.4
MEGAURLProvider: Unescaped url is: 10.2.4
MEGAURLProvider: Suffix is: _installer.pkg
MEGAURLProvider: Returning full url: https://www.megasoftware.net/do_force_download/MEGAX_10.2.4_installer.pkg 
{'Output': {'url': 'https://www.megasoftware.net/do_force_download/MEGAX_10.2.4_installer.pkg',
            'version': '10.2.4'}}
URLDownloader
{'Input': {'filename': 'MEGAXstandalone-osx-installer.pkg',
           'url': 'https://www.megasoftware.net/do_force_download/MEGAX_10.2.4_installer.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: File size returned by webserver matches that of the cached file: 90091193 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing /Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/downloads/MEGAXstandalone-osx-installer.pkg
{'Output': {'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/downloads/MEGAXstandalone-osx-installer.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.mega/receipts/Mega.download-receipt-20210407-133758.plist

Nothing downloaded, packaged or imported.
```