### PR TITLE
Update URLTextSearcher

### DIFF
--- a/Autodesk/Meshmixer.download.recipe
+++ b/Autodesk/Meshmixer.download.recipe
@@ -1,66 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
+  <dict>
     <key>Description</key>
     <string>Downloads the latest version of Meshmixer.</string>
     <key>Identifier</key>
     <string>com.github.hansen-m.download.Meshmixer</string>
     <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>Meshmixer</string>
-        <key>SEARCH_URL</key>
-        <string>https://www.meshmixer.com/download.html</string>
-        <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;http://www.meshmixer.com/downloads/Autodesk_Meshmixer_v[A-Za-z0-9_.]+_MacOS\.pkg)</string>
-        
+      <key>NAME</key>
+      <string>Meshmixer</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>Process</key>
     <array>
+      <dict>
+        <key>Processor</key>
+        <string>URLTextSearcher</string>
+        <key>Arguments</key>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
+          <key>url</key>
+          <string>https://meshmixer.com/download.html</string>
+          <key>re_pattern</key>
+          <string>href=.*?/Autodesk_Meshmixer_v?(\d+p\d+)_MacOS\.pkg</string>
+          <key>result_output_var_name</key>
+          <string>url_version</string>
         </dict>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>URLDownloader</string>
+        <key>Arguments</key>
         <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%url%</string>
-                <key>filename</key>
-                <string>%NAME%.pkg</string>
-            </dict>
+          <key>url</key>
+          <string>https://www.meshmixer.com/downloads/Autodesk_Meshmixer_v%url_version%_MacOS.pkg</string>
+          <key>filename</key>
+          <string>%NAME%.pkg</string>
         </dict>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Arguments</key>
         <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+          <key>expected_authority_names</key>
+          <array>
+            <string>Developer ID Installer: Autodesk (XXKJ396S2Y)</string>
+            <string>Developer ID Certification Authority</string>
+            <string>Apple Root CA</string>
+          </array>
+          <key>input_path</key>
+          <string>%pathname%</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: Autodesk (XXKJ396S2Y)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-            </dict>
-        </dict>
+        <key>Processor</key>
+        <string>CodeSignatureVerifier</string>
+      </dict>
     </array>
-</dict>
+  </dict>
 </plist>


### PR DESCRIPTION
Updated URLTextSearcher with new regex, here is the output:

```
~ autopkg run -vv Meshmixer.download
Processing Meshmixer.download...
WARNING: Meshmixer.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=.*?/Autodesk_Meshmixer_v?(\\d+p\\d+)_MacOS\\.pkg',
           'result_output_var_name': 'url_version',
           'url': 'https://meshmixer.com/download.html'}}
URLTextSearcher: Found matching text (url_version): 3p5
{'Output': {'url_version': '3p5'}}
URLDownloader
{'Input': {'filename': 'Meshmixer.pkg',
           'url': 'https://www.meshmixer.com/downloads/Autodesk_Meshmixer_v3p5_MacOS.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 05 Oct 2018 08:52:01 GMT
URLDownloader: Storing new ETag header: "a21c39c956cc5d94346ff4b252f3e98e-12"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/downloads/Meshmixer.pkg
{'Output': {'download_changed': True,
            'etag': '"a21c39c956cc5d94346ff4b252f3e98e-12"',
            'last_modified': 'Fri, 05 Oct 2018 08:52:01 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/downloads/Meshmixer.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/downloads/Meshmixer.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Autodesk '
                                        '(XXKJ396S2Y)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/downloads/Meshmixer.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Meshmixer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2018-04-03 13:04:52 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Autodesk (XXKJ396S2Y)
CodeSignatureVerifier:        Expires: 2022-02-28 18:39:13 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F3 67 CC 36 57 FC A1 9B 46 42 E0 5F 12 22 4C 91 73 58 4F 0E 31 5F 
CodeSignatureVerifier:            56 68 A1 95 4C 9D 9C 48 8A 22
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/receipts/Meshmixer-receipt-20210503-084458.plist

The following new items were downloaded:
    Download Path                                                                                      
    -------------                                                                                      
    /Users/admin/Library/AutoPkg/Cache/com.github.hansen-m.download.Meshmixer/downloads/Meshmixer.pkg
```