### PR TITLE
Update URLTextSearcher processor for Prey

### DIFF
--- a/PreyProject/Prey.download.recipe
+++ b/PreyProject/Prey.download.recipe
@@ -13,9 +13,7 @@
         <key>SEARCH_URL</key>
         <string>https://preyproject.com/download</string>
         <key>SEARCH_PATTERN</key>
- 		<string>\/templates.*Download.[0-9,a-z,A-Z]{0,8}.js</string>
-        <key>SEARCH_PATTERN2</key>
- 		<string>(?P&lt;url&gt;https:\/\/downloads.preyproject.com\/prey-client-releases\/node-client\/(?P&lt;version&gt;[0-9.]+)\/prey-mac-[0-9.]+-x64\.pkg)</string>
+        <string>(?P&lt;url&gt;https:\/\/downloads.preyproject.com\/prey-client-releases\/node-client\/(?P&lt;version&gt;[0-9.]+)\/prey-mac-[0-9.]+-x64\.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
@@ -34,22 +32,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://preyproject.com%match%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN2%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%url%</string>
+                <string>%match%</string>
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
             </dict>


### PR DESCRIPTION
Prey download page (https://preyproject.com/download/) now contains the pkg URL in the source. No longer need to have two `URLTextSearcher` processors to get the download address from another page. This uses the same regex to target https://preyproject.com/download/. Please test and merge. Thank you!