### PR TITLE
Update HachoirMetaDataProvider3.py

### DIFF
--- a/SharedProcessors/HachoirMetaDataProvider3.py
+++ b/SharedProcessors/HachoirMetaDataProvider3.py
@@ -94,7 +94,14 @@ class HachoirMetaDataProvider3(Processor):
         self.output("Examining: %s" % file_path)
         meta_data = self.getMetaData(file_path)
 
-        
+        if verbosity > 2:
+            self.output("Possible keys:")
+            for k in meta_data._Metadata__data:
+                if k:
+                    # print(k) # print all keys
+                    if meta_data.has(k):
+                        self.output(f"  key name: `{k}`")
+
         if verbosity > 1:
             for line in meta_data.exportPlaintext():
                 self.output(line)


### PR DESCRIPTION
add ability to get all possible key names to query from if verbosity >= 3

The keynames you can query are not the same as the way the keynames get displayed from `meta_data.exportPlaintext()` which is annoying when you are trying to figure out how to query different ones.