### PR TITLE
Modified regex to account for new download URL

### DIFF
--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>https://inkscape.org</string>
         <key>SEARCH_PATTERN1</key>
-        <string>(/release/inkscape-([0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/1010-1015/dl/)</string>
+        <string>(/release/inkscape-([0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/dmg/dl/)</string>
         <key>SEARCH_PATTERN2</key>
         <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>    
     </dict>


### PR DESCRIPTION
As per the comment from arekdist; the download URL for Inkscape has altered, therefore, SEARCH_PATTERN1 needed this change.