### PR TITLE
Use static download URL for Box Sync

### DIFF
--- a/Box/BoxSync.download.recipe
+++ b/Box/BoxSync.download.recipe
@@ -10,10 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Box Sync</string>
-		<key>URL</key>
-		<string>https://community.box.com/t5/Using-Box-Sync/Installing-Box-Sync/ta-p/85</string>
-		<key>USER_AGENT</key>
-		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/600.8.9 (KHTML, like Gecko) Version/8.0.8 Safari/600.8.9</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.1</string>
@@ -21,23 +17,11 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%URL%</string>
-				<!-- e.g. https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg-->
-				<key>re_pattern</key>
-				<string>(https://\w+\.\w+\.\w+/box-installers/sync/Sync\+4\+External/Box%20Sync%20Installer.dmg)</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%match%</string>
+				<string>https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
The [support article](https://support.box.com/hc/en-us/articles/360043697194-Installing-Box-Sync) providing a link to the Box Sync download now returns a 403 unless the requesting agent/browser can pass CloudFlare checks. Since the URL does not appear to change for new versions of Box, using the static URL appears to be a good workaround.

Resolves #201.

Run output from the download and pkg recipes:

```
% autopkg run -vv Box/BoxSync.download.recipe
Processing Box/BoxSync.download.recipe...
WARNING: Box/BoxSync.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Box Sync.dmg',
           'url': 'https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hansen-m.download.boxsync/downloads/Box Sync.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hansen-m.download.boxsync/downloads/Box '
                        'Sync.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.download.boxsync/downloads/Box '
                         'Sync.dmg/Box Sync.app',
           'requirement': 'identifier "com.box.sync" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = M683GB7CPW'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hansen-m.download.boxsync/downloads/Box Sync.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ipwM5o/Box Sync.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ipwM5o/Box Sync.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ipwM5o/Box Sync.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hansen-m.download.boxsync/receipts/BoxSync.download-receipt-20211012-161323.plist

Nothing downloaded, packaged or imported.
```

```
% autopkg run -vv Box/BoxSync.pkg.recipe     
Processing Box/BoxSync.pkg.recipe...
WARNING: Box/BoxSync.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Box Sync.dmg',
           'url': 'https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 22 Sep 2021 17:31:50 GMT
URLDownloader: Storing new ETag header: "b6086c1e96294c376605019f3c02078b"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box Sync.dmg
{'Output': {'download_changed': True,
            'etag': '"b6086c1e96294c376605019f3c02078b"',
            'last_modified': 'Wed, 22 Sep 2021 17:31:50 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box '
                        'Sync.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box '
                                                                        'Sync.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box '
                         'Sync.dmg/Box Sync.app',
           'requirement': 'identifier "com.box.sync" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = M683GB7CPW'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box Sync.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.mEp0RX/Box Sync.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.mEp0RX/Box Sync.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.mEp0RX/Box Sync.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '01775',
                       'Library': '01775',
                       'Library/PrivilegedHelperTools': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications
PkgRootCreator: Creating Library
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library
PkgRootCreator: Creating Library/PrivilegedHelperTools
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library/PrivilegedHelperTools
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box '
                               'Sync.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box '
                          'Sync.dmg/Box Sync.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box Sync.dmg, dmg: .dmg/, dmg_source_path: Box Sync.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box Sync.dmg
Copier: Copied /private/tmp/dmg.thpOCB/Box Sync.app to ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library/PrivilegedHelperTools/com.box.sync.bootstrapper',
           'source_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box '
                          'Sync.app/Contents/Resources/com.box.sync.bootstrapper'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app/Contents/Resources/com.box.sync.bootstrapper, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app/Contents/Resources/com.box.sync.bootstrapper to ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library/PrivilegedHelperTools/com.box.sync.bootstrapper
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library/PrivilegedHelperTools/com.box.sync.iconhelper',
           'source_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box '
                          'Sync.app/Contents/Resources/com.box.sync.iconhelper'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app/Contents/Resources/com.box.sync.iconhelper, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app/Contents/Resources/com.box.sync.iconhelper to ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Library/PrivilegedHelperTools/com.box.sync.iconhelper
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box '
                               'Sync.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 4.0.8041 in file ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync/Applications/Box Sync.app/Contents/Info.plist
{'Output': {'version': '4.0.8041'}}
PkgInfoCreator
{'Input': {'infofile': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/PackageInfo',
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync',
           'pkgtype': 'flat',
           'template_path': 'PackageInfoTemplate',
           'version': '4.0.8041'}}
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'},
                                     {'group': 'wheel',
                                      'path': 'Library',
                                      'user': 'root'},
                                     {'group': 'wheel',
                                      'mode': '4755',
                                      'path': 'Library/PrivilegedHelperTools/com.box.sync.bootstrapper',
                                      'user': 'root'},
                                     {'group': 'wheel',
                                      'mode': '4755',
                                      'path': 'Library/PrivilegedHelperTools/com.box.sync.iconhelper',
                                      'user': 'root'}],
                           'id': 'com.box.pkg.boxsync',
                           'infofile': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/PackageInfo',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync',
                           'pkgname': 'BoxSync-4.0.8041'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.box.pkg.boxsync',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync-4.0.8041.pkg',
                                                    'version': '4.0.8041'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync-4.0.8041.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/receipts/BoxSync.pkg-receipt-20211012-161732.plist

The following new items were downloaded:
    Download Path                                                                                
    -------------                                                                                
    ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/downloads/Box Sync.dmg  

The following packages were built:
    Identifier           Version   Pkg Path                                                                                   
    ----------           -------   --------                                                                                   
    com.box.pkg.boxsync  4.0.8041  ~/Library/AutoPkg/Cache/com.github.hansen-m.pkg.boxsync/BoxSync-4.0.8041.pkg  
```