### PR TITLE
Default the Python Major Version to 3

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -15,11 +15,12 @@ to chose between 'sh' or 'pkg'.</string>
         <key>NAME</key>
         <string>Anaconda</string>
         <key>PYTHON_MAJOR_VERSION</key>
-        <string>2</string>
+        <string>3</string>
         <key>SEARCH_URL</key>
         <string>https://www.anaconda.com/download/#macos</string>
+        <!-- Just to note, for future reference, incase it breaks, the above page is being redirected to:  https://www.anaconda.com/products/individual -->
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.(anaconda|continuum)\.(com|io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
+        <string>(?P&lt;url&gt;https\://repo\.(anaconda\.com|continuum\.io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
Updated to change the `PYTHON_MAJOR_VERSION` to `3`.

Updated the `SEARCH_PATTERN` to be **more** _correct_.

Included a note regarding the current `SEARCH_URL` page being redirected to a new page.  Since it currently works, I see no need to change it.