### PR TITLE
Update MeshLab.download.recipe

### DIFF
--- a/MeshLab/MeshLab.download.recipe
+++ b/MeshLab/MeshLab.download.recipe
@@ -14,32 +14,42 @@
     <key>MinimumVersion</key>
     <string>0.6.1</string>
     <key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>github_repo</key>
-				<string>cnr-isti-vclab/meshlab</string>
-				<key>asset_regex</key>
-				<string>.*-macos.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>GitHubReleasesInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>github_repo</key>
+                <string>cnr-isti-vclab/meshlab</string>
+                <key>asset_regex</key>
+                <string>.*-macos.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/MeshLab*.app</string>
+                <key>requirement</key>
+                <string>identifier "com.vcg.meshlab" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UD5NTZR656</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
 </dict>
 </plist>
-


### PR DESCRIPTION
Hi, @hansen-m 

This PR adds in `CodeSignatureVerifier`, to the MeshLab Download Recipe. 

Thanks!

-vvv output

```
autopkg run -vvv --post "io.github.hjuutilainen.VirusTotalAnalyzer/VirusTotalAnalyzer" /Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab/MeshLab.download.recipe
Processing /Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab/MeshLab.download.recipe...
WARNING: /Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab/MeshLab.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.4.1',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'MeshLab',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab/MeshLab.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer'],
 'VIRUSTOTAL_API_KEY': 'd738c21b9df9e192f4f00398cab0fd87de85786b1f28304788d9af6edce5a962',
 'VIRUSTOTAL_AUTO_SUBMIT': True,
 'VIRUSTOTAL_AUTO_SUBMIT_MAX_SIZE': 1073741824,
 'VIRUSTOTAL_SLEEP_SECONDS': 30,
 'verbose': 3}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*-macos.dmg',
           'github_repo': 'cnr-isti-vclab/meshlab'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*-macos.dmg' among asset(s): MeshLab2022.02-linux.AppImage, MeshLab2022.02-linux.tar.gz, MeshLab2022.02-macos.dmg, MeshLab2022.02-macos.tar.gz, MeshLab2022.02-windows.exe, MeshLab2022.02-windows.zip, MeshLab2022.02d-linux.AppImage, MeshLab2022.02d-linux.tar.gz, MeshLab2022.02d-macos.dmg, MeshLab2022.02d-macos.tar.gz, MeshLab2022.02d-windows.exe, MeshLab2022.02d-windows.zip
GitHubReleasesInfoProvider: Selected asset 'MeshLab2022.02-macos.dmg' from release 'MeshLab-2022.02'
{'Output': {'asset_url': 'https://api.github.com/repos/cnr-isti-vclab/meshlab/releases/assets/58327651',
            'url': 'https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-2022.02/MeshLab2022.02-macos.dmg',
            'version': 'MeshLab-2022.02'}}
URLDownloader
{'Input': {'filename': 'MeshLab.dmg',
           'url': 'https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-2022.02/MeshLab2022.02-macos.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 02 Mar 2022 11:27:09 GMT
URLDownloader: Storing new ETag header: "0x8D9FC3F96F08E6D"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8D9FC3F96F08E6D"',
            'last_modified': 'Wed, 02 Mar 2022 11:27:09 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg/MeshLab*.app',
           'requirement': 'identifier "com.vcg.meshlab" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UD5NTZR656'}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.TExggr/MeshLab2022.02.app' matched from globbed '/private/tmp/dmg.TExggr/MeshLab*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.TExggr/MeshLab2022.02.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.TExggr/MeshLab2022.02.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.TExggr/MeshLab2022.02.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
io.github.hjuutilainen.VirusTotalAnalyzer/VirusTotalAnalyzer
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'VIRUSTOTAL_AUTO_SUBMIT': True,
           'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg'}}
VirusTotalAnalyzer: Calculating checksum for /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg
VirusTotalAnalyzer: Requesting report...
VirusTotalAnalyzer: Response code: 1
VirusTotalAnalyzer: Message: Scan finished, information embedded
VirusTotalAnalyzer: Scan ID: 05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5-1649857321
VirusTotalAnalyzer: Detection ratio: 0/57
VirusTotalAnalyzer: Scan date: 2022-04-13 13:42:01
VirusTotalAnalyzer: Permalink: https://www.virustotal.com/gui/file/05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5/detection/f-05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5-1649857321
{'Output': {'virus_total_analyzer_summary_result': {'data': {'name': 'MeshLab.dmg',
                                                             'permalink': 'https://www.virustotal.com/gui/file/05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5/detection/f-05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5-1649857321',
                                                             'ratio': '0/57'},
                                                    'report_fields': ['name',
                                                                      'ratio',
                                                                      'permalink'],
                                                    'summary_text': 'The '
                                                                    'following '
                                                                    'items '
                                                                    'were '
                                                                    'queried '
                                                                    'from the '
                                                                    'VirusTotal '
                                                                    'database:'}}}
{'AUTOPKG_VERSION': '2.4.1',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'GITHUB_TOKEN_PATH': '~/.autopkg_gh_token',
 'GITHUB_URL': 'https://api.github.com',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'MeshLab',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/hansen-m-recipes/MeshLab/MeshLab.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer'],
 'VIRUSTOTAL_API_KEY': 'd738c21b9df9e192f4f00398cab0fd87de85786b1f28304788d9af6edce5a962',
 'VIRUSTOTAL_AUTO_SUBMIT': True,
 'VIRUSTOTAL_AUTO_SUBMIT_MAX_SIZE': 1073741824,
 'VIRUSTOTAL_SLEEP_SECONDS': 30,
 'asset_regex': '.*-macos.dmg',
 'asset_url': 'https://api.github.com/repos/cnr-isti-vclab/meshlab/releases/assets/58327651',
 'download_changed': True,
 'etag': '"0x8D9FC3F96F08E6D"',
 'filename': 'MeshLab.dmg',
 'github_repo': 'cnr-isti-vclab/meshlab',
 'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg/MeshLab*.app',
 'last_modified': 'Wed, 02 Mar 2022 11:27:09 GMT',
 'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg',
 'prefetch_filename': False,
 'release_notes': '',
 'requirement': 'identifier "com.vcg.meshlab" and anchor apple generic and '
                'certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ '
                'and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = UD5NTZR656',
 'url': 'https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-2022.02/MeshLab2022.02-macos.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': 'MeshLab-2022.02',
 'virus_total_analyzer_summary_result': {'data': {'name': 'MeshLab.dmg',
                                                  'permalink': 'https://www.virustotal.com/gui/file/05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5/detection/f-05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5-1649857321',
                                                  'ratio': '0/57'},
                                         'report_fields': ['name',
                                                           'ratio',
                                                           'permalink'],
                                         'summary_text': 'The following items '
                                                         'were queried from '
                                                         'the VirusTotal '
                                                         'database:'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/receipts/MeshLab.download-receipt-20220513-132541.plist

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.MeshLab/downloads/MeshLab.dmg  

The following items were queried from the VirusTotal database:
    Name         Ratio  Permalink                                                                                                                                                                                     
    ----         -----  ---------                                                                                                                                                                                     
    MeshLab.dmg  0/57   https://www.virustotal.com/gui/file/05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5/detection/f-05ed6aa47f48ea5d2102c4952c0cfd5dfd6b9a56090d67d4c09d59ecb73214b5-1649857321
```