### PR TITLE
Universal installer support for VueScan

### DIFF
--- a/VueScan/VueScan.download.recipe
+++ b/VueScan/VueScan.download.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version VueScan. Defaults to 64-bit version, override by setting ARCH to '32'.</string>
+    <string>Downloads the latest version VueScan (Universal installer).</string>
     <key>Identifier</key>
     <string>com.github.hansen-m.download.VueScan</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>VueScan</string>
-        <key>ARCH</key>
-        <string>64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -25,7 +23,7 @@
                 <key>url</key>
                 <string>https://www.hamrick.com/alternate-versions.html</string>
                 <key>re_pattern</key>
-                <string>href="files/(vuex%ARCH%[\d]+\.dmg)"</string>
+                <string>href="files/(vuea64[\d]+\.dmg)"</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The current VueScan recipe downloads the Intel app (32-bit or 64-bit, depending on the value of `ARCH`). Hamrick now offers a Universal installer. I am suggesting that the recipe be simplified by eliminating the ARCH option and always downloading the Universal app. Alternately, you could change the code to require that ARCH be set to one of `a64` (ARM/Universal), `x64` (Intel 64-bit), or `x32` (Intel 32-bit) and alter the download string accordingly, but that would break all existing overrides for the "benefit" of being able to get the 32-bit version automatically (hence the choice made in this PR).