### PR TITLE
Mega Software: fix bug with html unescape

### DIFF
--- a/MegaSoftware/MEGAUrlProvider.py
+++ b/MegaSoftware/MEGAUrlProvider.py
@@ -16,6 +16,7 @@ import sys
 try:
     # import for Python 3
     from html.parser import HTMLParser
+    import html
 except ImportError:
     # import for Python 2
     from HTMLParser import HTMLParser
@@ -44,7 +45,7 @@ class MEGAURLProvider(URLGetter):
         else:
             html_source = self.download(VERSION_URL).decode("utf-8")
         escaped_url = re.search(REGEX, html_source).group(1)
-        unescaped_url = HTMLParser().unescape(escaped_url)
+        unescaped_url = html.unescape(escaped_url)
         suffix = "_installer.pkg"
         return_url = BASE_URL + unescaped_url + suffix
         self.env["version"] = escaped_url


### PR DESCRIPTION
From Python 3.9 `HTMLParser()` does not have the method `unescape` anymore. Therefore running the recipe causes this error: `AttributeError: 'HTMLParser' object has no attribute 'unescape'`

The easy solution is to just do it with the `html` module imported: https://stackoverflow.com/a/70793745