### PR TITLE
Update AdobeCreativeCloudInstaller-Win.download.recipe

### DIFF
--- a/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>CreativeCloudInstaller</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://ccmdls.adobe.com/AdobeProducts/KCCC/1/win32/CreativeCloudSet-Up.exe</string>
+		<string>https://prod-rel-ffc-ccm.oobesaas.adobe.com/adobe-ffc-external/core/v1/wam/download?sapCode=KCCC&productName=Creative%20Cloud&os=win&environment=prod</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
update to newer download location. This currently downloads version 5.3.5.13 while the previous URL seemed to download 4.x version.