### PR TITLE
Depreciate Fitbit Recipes

### DIFF
--- a/Fitbit/Fitbit.download.recipe
+++ b/Fitbit/Fitbit.download.recipe
@@ -18,9 +18,29 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1.0</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.
+
+For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -28,8 +48,8 @@
             <dict>
                 <key>request_headers</key>
                 <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
                 </dict>
                 <key>url</key>
                 <string>%SEARCH_URL%</string>

--- a/Fitbit/Fitbit.install.recipe
+++ b/Fitbit/Fitbit.install.recipe
@@ -12,11 +12,31 @@
         <string>Fitbit</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.Fitbit</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.
+
+For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>


### PR DESCRIPTION
Hi, @hansen-m (@rustymyers) 

This PR depreciates the Munki recipe. The Fitbit macOS application is no longer available from the vendor.

For further information please see the following community post: https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569

Thanks!

```
autopkg run -v /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.download.recipe 
Processing /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.download.recipe...
WARNING: /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
DeprecationWarning: This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569
StopProcessingIf
StopProcessingIf: (TRUEPREDICATE) is True
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.download.Fitbit/receipts/Fitbit.download-receipt-20221019-122448.plist

The following recipes have deprecation warnings:
    Name             Warning                                                                                                                                                                                                                                                                                                                          
    ----             -------                                                                                                                                                                                                                                                                                                                          
    Fitbit.download  This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569
```

and

```
autopkg run -v /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.install.recipe 
Processing /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.install.recipe...
WARNING: /Users/paul/Documents/GitHub/hansen-m-recipes/Fitbit/Fitbit.install.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
DeprecationWarning: This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569
StopProcessingIf
StopProcessingIf: (TRUEPREDICATE) is True
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.hansen-m.install.Fitbit/receipts/Fitbit.install-receipt-20221019-122459.plist

The following recipes have deprecation warnings:
    Name            Warning                                                                                                                                                                                                                                                                                                                          
    ----            -------                                                                                                                                                                                                                                                                                                                          
    Fitbit.install  This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569
```