### PR TITLE
Use variable in pkgname for PyCharm

### DIFF
--- a/PyCharm/PyCharm.pkg.recipe
+++ b/PyCharm/PyCharm.pkg.recipe
@@ -64,7 +64,7 @@
                 <key>pkg_request</key>
                 <dict>
                     <key>pkgname</key>
-                    <string>PyCharmCE-%version%</string>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
With the pkgname hardcoded, it's not possible to have separate overrides for x86 and arm version, since the resulting package would have the same name. Using %NAME% allows setting a different name in an override.