### PR TITLE
Anaconda: New Regex because of new version name, adding arch as variable

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -19,7 +19,7 @@ to chose between 'sh' or 'pkg'.</string>
         <key>ARCH</key>
         <string>x86_64</string>
         <key>SEARCH_URL</key>
-        <string>https://www.anaconda.com/download#macos</string>
+        <string>https://www.anaconda.com/download/#macos</string>
         <!-- Just to note, for future reference, incase it breaks, the above page is being redirected to:  https://www.anaconda.com/products/individual -->
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;https\://repo\.(anaconda\.com|continuum\.io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.|-]+)-MacOSX-%ARCH%\.%INSTALLER_TYPE%)</string>

--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -16,11 +16,13 @@ to chose between 'sh' or 'pkg'.</string>
         <string>Anaconda</string>
         <key>PYTHON_MAJOR_VERSION</key>
         <string>3</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
         <key>SEARCH_URL</key>
-        <string>https://www.anaconda.com/download/#macos</string>
+        <string>https://www.anaconda.com/download#macos</string>
         <!-- Just to note, for future reference, incase it breaks, the above page is being redirected to:  https://www.anaconda.com/products/individual -->
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https\://repo\.(anaconda\.com|continuum\.io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.]+)-MacOSX-x86_64\.%INSTALLER_TYPE%)</string>
+        <string>(?P&lt;url&gt;https\://repo\.(anaconda\.com|continuum\.io)/archive/Anaconda%PYTHON_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.|-]+)-MacOSX-%ARCH%\.%INSTALLER_TYPE%)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
Because of the new Version `2023.03-1` the `URLTextSearcher` is coming up empty when running the Recipe. 
The new Regex fixes that (although it is still a bad versioning name). 

Additionally added an architecture variable to the recipe. 

output for `autopkg run -vv Continuum/Anaconda.download.recipe    `:
```
Processing Continuum/Anaconda.download.recipe...
WARNING: Continuum/Anaconda.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'Python (?P<PYTHON_VERSION>3\\.\\d)',
           'url': 'https://www.anaconda.com/download/#macos'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (PYTHON_VERSION): 3.1
URLTextSearcher: Found matching text (match): 3.1
{'Output': {'PYTHON_VERSION': '3.1', 'match': '3.1'}}
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>https\\://repo\\.(anaconda\\.com|continuum\\.io)/archive/Anaconda3-(?P<version>[0-9.|-]+)-MacOSX-x86_64\\.sh)',
           'result_output_var_name': 'match',
           'url': 'https://www.anaconda.com/download/#macos'}}
URLTextSearcher: Found matching text (url): https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh
URLTextSearcher: Found matching text (version): 2023.03-1
URLTextSearcher: Found matching text (match): https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh
{'Output': {'match': 'https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh',
            'url': 'https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh',
            'version': '2023.03-1'}}
URLDownloader
{'Input': {'filename': 'Anaconda3-2023.03-1.sh',
           'url': 'https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3-2023.03-1.sh
{'Output': {'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3-2023.03-1.sh'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/receipts/Anaconda.download-receipt-20230428-124037.plist

Nothing downloaded, packaged or imported.
```