### PR TITLE
Add try/except to account for index out of range error

### DIFF
--- a/SharedProcessors/GoogleChromeWinVersioner.py
+++ b/SharedProcessors/GoogleChromeWinVersioner.py
@@ -110,9 +110,16 @@ class GoogleChromeWinVersioner(Processor):
 
         pattern = re.compile(version_regex)
 
-        with io.open(extract_path + "/[5]SummaryInformation", encoding="latin-1") as file:
-            data = file.read()
-            msiversion = pattern.findall(data)[0]
+        try:
+            with io.open(extract_path + "/[5]SummaryInformation", encoding="latin-1") as file:
+                data = file.read()
+                msiversion = pattern.findall(data)[0]
+        except:
+            version_regex = '(?<=manifest version=\")[0-9]{1,3}.[0-9].[0-9]{4}.[0-9]{1,4}'
+            pattern = re.compile(version_regex)
+            with io.open(extract_path + "/Binary.GoogleChromeInstaller", encoding="latin-1") as file:
+                data = file.read()
+                msiversion = pattern.findall(data)[0]
         if msiversion != "":
             self.env[output_var_name] = msiversion
         else:


### PR DESCRIPTION
For 32 bit Windows download, the file that had been searched to retrieve the version no longer contained that data so the regex was not finding any information.  The only other place I was able to find it was in the installer binary, which, while not ideal at least was preceded by "manifest version" which at least reads as important enough to be consistent.  It will only search that if the initial search fails, as I am unsure if this was an error on google's part that will be resolved in a future release or not.