### PR TITLE
Deprecate Blackboard Collaborate Launcher recipes

### DIFF
--- a/Blackboard/BlackboardCollaborateLauncher.download.recipe
+++ b/Blackboard/BlackboardCollaborateLauncher.download.recipe
@@ -12,7 +12,7 @@
         <string>Blackboard Collaborate Launcher</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Blackboard/BlackboardCollaborateLauncher.download.recipe
+++ b/Blackboard/BlackboardCollaborateLauncher.download.recipe
@@ -17,6 +17,10 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The appcast URL used by this recipe is no longer online and I can't find a replacement. This PR marks the recipes as deprecated pending removal.