### PR TITLE
Deprecate Xamarin Studio recipes

### DIFF
--- a/Xamarin/XamarinStudio.download.recipe
+++ b/Xamarin/XamarinStudio.download.recipe
@@ -19,6 +19,15 @@
     <string>0.2.9</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Monodevelop (aka Xamarin Studio) is no longer under active developement (details: https://www.monodevelop.com/download/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Monodevelop (aka Xamarin Studio) is no longer under active developement ([details](https://www.monodevelop.com/download/)). This PR deprecates the Xamarin Studio recipes.
