### PR TITLE
Deprecate SketchPad 5 recipes

### DIFF
--- a/KeyCurriculum/Sketchpad5.download.recipe
+++ b/KeyCurriculum/Sketchpad5.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the GSP5 recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The Geometer's SketchPad 5 recipes in this repo are no longer downloading. This PR deprecates the SketchPad recipes and points to working equivalents in my homebysix-recipes repo.
