### PR TITLE
Deprecate Juno recipes

### DIFF
--- a/Julia/Juno.download.recipe
+++ b/Julia/Juno.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Juno is no longer being updated (details: https://junolab.org/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Juno will not receive any further updates ([details](https://junolab.org/)). This PR deprecates the Juno recipes.
