### PR TITLE
Deprecate Julia Studio recipes

### DIFF
--- a/Julia/JuliaStudio.download.recipe
+++ b/Julia/JuliaStudio.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Development and distribution of Julia Studio has been discontinued (details: https://github.com/forio/julia-studio/issues/268#issuecomment-552118996). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Development and distribution of Julia Studio has been discontinued ([details](https://github.com/forio/julia-studio/issues/268#issuecomment-552118996)). This PR deprecates the Julia Studio recipes.
