### PR TITLE
Deprecate Kolor recipes

### DIFF
--- a/Kolor/KolorGoProVRPlayer-Win.download.recipe
+++ b/Kolor/KolorGoProVRPlayer-Win.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Kolor is closed and existing Kolor products will no longer be updated (details: https://kolor.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Kolor/KolorGoProVRPlayer.download.recipe
+++ b/Kolor/KolorGoProVRPlayer.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Kolor is closed and existing Kolor products will no longer be updated (details: https://kolor.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Kolor is closed and existing Kolor products will no longer be updated ([details](https://kolor.com)). This PR deprecates Kolor GoProVRPlayer recipes.
