### PR TITLE
Deprecate CDBS recipes

### DIFF
--- a/Astronomy/IRAFCDBS.download.recipe
+++ b/Astronomy/IRAFCDBS.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The CDBS download is no longer available. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The CDBS download is no longer available. This PR deprecates the CDBS recipes.
