### PR TITLE
Deprecate FileZilla recipes

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -18,9 +18,18 @@
         <string>release</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the FileZilla recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional FileZilla recipes in this repo, which are not sufficiently distinct from the ones in keeleysam-recipes to merit the extra maintenance effort. The included deprecation message points users to keeleysam-recipes for alternatives.
