### PR TITLE
MinimumVersion, EndOfCheckPhase, and NAME variable best practices

### DIFF
--- a/Adobe/AdobeDigitalEditions.install.recipe
+++ b/Adobe/AdobeDigitalEditions.install.recipe
@@ -26,10 +26,6 @@
                 <string>%pathname%/Digital Editions [0-9].* Installer.pkg</string>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/Adobe/AdobeReader-Win.download.recipe
+++ b/Adobe/AdobeReader-Win.download.recipe
@@ -16,7 +16,7 @@
         <string>Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Anki/Anki.download.recipe
+++ b/Anki/Anki.download.recipe
@@ -21,7 +21,7 @@ Create an input variable called include_prereleases and set to a non-empty strin
         <string>.*apple.*</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Apple/QuickTime-Win.download.recipe
+++ b/Apple/QuickTime-Win.download.recipe
@@ -20,7 +20,7 @@
         <string>Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Astronomy/AstroPlanner.download.recipe
+++ b/Astronomy/AstroPlanner.download.recipe
@@ -12,7 +12,7 @@
         <string>AstroPlanner</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Astronomy/AstroPlanner.pkg.recipe
+++ b/Astronomy/AstroPlanner.pkg.recipe
@@ -12,7 +12,7 @@
         <string>AstroPlanner</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.AstroPlanner</string>
     <key>Process</key>

--- a/Astronomy/IRAFCDBS.download.recipe
+++ b/Astronomy/IRAFCDBS.download.recipe
@@ -12,7 +12,7 @@
         <string>CDBS</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Autodesk/Meshmixer.download.recipe
+++ b/Autodesk/Meshmixer.download.recipe
@@ -12,7 +12,7 @@
       <string>Meshmixer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
       <dict>

--- a/BESEngine/BESEngine.install.recipe
+++ b/BESEngine/BESEngine.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/BESEngine/BESEngine.pkg.recipe
+++ b/BESEngine/BESEngine.pkg.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>

--- a/BESPythonAPI/BESPythonAPI.install.recipe
+++ b/BESPythonAPI/BESPythonAPI.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/BESPythonAPI/BESPythonAPI.pkg.recipe
+++ b/BESPythonAPI/BESPythonAPI.pkg.recipe
@@ -21,10 +21,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>

--- a/BigFix/BigFixAgent.download.recipe
+++ b/BigFix/BigFixAgent.download.recipe
@@ -14,7 +14,7 @@
         <string>https://support.bigfix.com/bes/release</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/BigFix/QnA.install.recipe
+++ b/BigFix/QnA.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/BigFix/QnA.pkg.recipe
+++ b/BigFix/QnA.pkg.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>FlatPkgUnpacker</string>
             <key>Arguments</key>
             <dict>

--- a/Box/BoxSync.install.recipe
+++ b/Box/BoxSync.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/CodingMonkeys/SubEthaEdit.download.recipe
+++ b/CodingMonkeys/SubEthaEdit.download.recipe
@@ -14,7 +14,7 @@
         <string>https://subethaedit.net/SubEthaEdit.zip</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/CodingMonkeys/SubEthaEdit.download.recipe
+++ b/CodingMonkeys/SubEthaEdit.download.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/app/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/app/SubEthaEdit.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "de.codingmonkeys.SubEthaEdit.MacFULL" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S76GCAG929)</string>
             </dict>

--- a/CodingMonkeys/SubEthaEdit.pkg.recipe
+++ b/CodingMonkeys/SubEthaEdit.pkg.recipe
@@ -35,15 +35,15 @@
         </dict>
         <dict>
             <key>Comment</key>
-            <string>Copy %NAME%.app</string>
+            <string>Copy SubEthaEdit.app</string>
             <key>Processor</key>
             <string>Copier</string>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/app/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/app/SubEthaEdit.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/SubEthaEdit.app</string>
             </dict>
         </dict>
         <dict>
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/SubEthaEdit.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/Contour/ContourShuttleDriver.download.recipe
+++ b/Contour/ContourShuttleDriver.download.recipe
@@ -28,7 +28,11 @@
                 <string>Contour-Shuttle-Driver.zip</string>
             </dict>
         </dict>
-            <dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>Unarchiver</string>
         </dict>
@@ -60,10 +64,6 @@
                 <key>dmg_path</key>
                 <string>%found_filename%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Contour/ContourShuttleDriver.pkg.recipe
+++ b/Contour/ContourShuttleDriver.pkg.recipe
@@ -12,7 +12,7 @@
         <string>Contour Shuttle Driver</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.ContourShuttleDriver</string>
     <key>Process</key>

--- a/Contour/ContourShuttleDriver.pkg.recipe
+++ b/Contour/ContourShuttleDriver.pkg.recipe
@@ -39,10 +39,6 @@
                 <string>%found_filename%/Contour Shuttle.app</string>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/Dymo/DymoLabel.pkg.recipe
+++ b/Dymo/DymoLabel.pkg.recipe
@@ -20,10 +20,6 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>flat_pkg_path</key>

--- a/Dymo/DymoLabel.pkg.recipe
+++ b/Dymo/DymoLabel.pkg.recipe
@@ -64,6 +64,17 @@
             <key>Processor</key>
             <string>PathDeleter</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_pkg</key>
+                <string>%pathname%/*.pkg</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/FeltTip/SoundStudio.download.recipe
+++ b/FeltTip/SoundStudio.download.recipe
@@ -18,7 +18,7 @@
         <string>(?P&lt;dmg&gt;sound_studio_.*\.zip)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
        <dict>

--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;download.gimp.org/gimp/v.*?/macos/gimp-.*?.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Google/GoogleVoiceAndVideo.install.recipe
+++ b/Google/GoogleVoiceAndVideo.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/Greenshot/Greenshot-Win.download.recipe
+++ b/Greenshot/Greenshot-Win.download.recipe
@@ -17,7 +17,7 @@
         <string>Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/ImgBurn/ImgBurn-Win.download.recipe
+++ b/ImgBurn/ImgBurn-Win.download.recipe
@@ -16,7 +16,7 @@
         <string>Current version\: (?P&lt;version&gt;[0-9.]+)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -22,7 +22,7 @@
         <string>dmg</string>  
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Julia/JuliaStudio.download.recipe
+++ b/Julia/JuliaStudio.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;https://s3\.amazonaws\.com/cdn-common\.forio\.com/julia-studio/.*?/julia-studio-macx-installer-.*?\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Julia/Juno.download.recipe
+++ b/Julia/Juno.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;https://junolab\.s3\.amazonaws\.com/release/(?P&lt;version&gt;[0-9.]+)/juno-mac-x64\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Keka/Keka.download.recipe
+++ b/Keka/Keka.download.recipe
@@ -14,7 +14,7 @@
         <string>aonez/Keka</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/KeyCurriculum/Sketchpad5.download.recipe
+++ b/KeyCurriculum/Sketchpad5.download.recipe
@@ -14,7 +14,7 @@
         <string>https://gsp5.s3.amazonaws.com/GSP5.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Kolor/KolorGoProVRPlayer-Win.download.recipe
+++ b/Kolor/KolorGoProVRPlayer-Win.download.recipe
@@ -14,7 +14,7 @@
         <string>https://download.kolor.com/ked/stable/x64</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Kolor/KolorGoProVRPlayer.download.recipe
+++ b/Kolor/KolorGoProVRPlayer.download.recipe
@@ -14,7 +14,7 @@
         <string>https://download.kolor.com/ked/stable/mac</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/MacPorts/MacPorts.install.recipe
+++ b/MacPorts/MacPorts.install.recipe
@@ -19,10 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/MacTeX/MacTeX.download.recipe
+++ b/MacTeX/MacTeX.download.recipe
@@ -14,7 +14,7 @@
         <string>http://www.tug.org/mactex/mactex-download.html</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>
@@ -44,4 +44,3 @@
     </array>
 </dict>
 </plist>
-

--- a/MakerBot/MakerBotDesktop-Win.download.recipe
+++ b/MakerBot/MakerBotDesktop-Win.download.recipe
@@ -18,7 +18,7 @@
         <string>curl/7.21.4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/MakerBot/MakerBotPrint-Win.download.recipe
+++ b/MakerBot/MakerBotPrint-Win.download.recipe
@@ -18,7 +18,7 @@
         <string>curl/7.21.4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/MakerBot/MakerBotPrint.download.recipe
+++ b/MakerBot/MakerBotPrint.download.recipe
@@ -18,7 +18,7 @@
         <string>curl/7.21.4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/McNeel/Rhinoceros.download.recipe
+++ b/McNeel/Rhinoceros.download.recipe
@@ -14,7 +14,7 @@
             <string>https://files.mcneel.com/rhino/7/mac/updates/commercialUpdates.xml</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>0.4.0</string>
+		<string>1.1</string>
 		<key>Process</key>
         <array>
             <dict>

--- a/Microbiology/Mothur.download.recipe
+++ b/Microbiology/Mothur.download.recipe
@@ -12,7 +12,7 @@
         <string>mothur</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Minitab/MinitabExpress.download.recipe
+++ b/Minitab/MinitabExpress.download.recipe
@@ -18,7 +18,7 @@
         <string>(?P&lt;url&gt;https://files3\.minitab\.com/prodinstalls/minitabexpress/minitabexpress1/(?P&lt;version&gt;[0-9.]+)/mac/multi-user/Minitab_Express_MU_v[0-9.]+\.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
        <dict>

--- a/NotepadPlusPlus/NotepadPlusPlus.download.recipe
+++ b/NotepadPlusPlus/NotepadPlusPlus.download.recipe
@@ -14,7 +14,7 @@
         <string>notepad-plus-plus/notepad-plus-plus</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/OverDrive/OverDrive.install.recipe
+++ b/OverDrive/OverDrive.install.recipe
@@ -26,10 +26,6 @@
                 <string>%pathname%/OverDrive-Mac-Installer-Version-*.pkg</string>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/Pencil/Pencil2D.download.recipe
+++ b/Pencil/Pencil2D.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;zip&gt;Pencil2D-.*?-mac\.zip)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/PollEverywhere/PollEverywhere.download.recipe
+++ b/PollEverywhere/PollEverywhere.download.recipe
@@ -14,7 +14,7 @@
         <string>https://www.polleverywhere.com/app.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Polycom/PolycomRPDesktop.download.recipe
+++ b/Polycom/PolycomRPDesktop.download.recipe
@@ -18,7 +18,7 @@
         <string>https://downloads\.polycom\.com/video/realpresence_desktop/RPDMac_(?P&lt;version&gt;.*?_.*?_.*?)_(?P&lt;bundle_version&gt;.*?)\.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/PreyProject/Prey.download.recipe
+++ b/PreyProject/Prey.download.recipe
@@ -28,7 +28,7 @@
              "https://downloads.preyproject.com/prey-client-releases/node-client/1.11.4/prey-windows-1.11.4-x86.exe" -->
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Processing/Processing.download.recipe
+++ b/Processing/Processing.download.recipe
@@ -12,7 +12,7 @@
         <string>Processing</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/PyCharm/PyCharm.download.recipe
+++ b/PyCharm/PyCharm.download.recipe
@@ -16,7 +16,7 @@
         <string>mac":{"link":"([^,]*?20\d{2,2}(.\d{1,4}){1,3}.dmg)"</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/PyCharm/PyCharm.munki.recipe
+++ b/PyCharm/PyCharm.munki.recipe
@@ -35,7 +35,7 @@
     </dict>
   </dict>
   <key>MinimumVersion</key>
-  <string>0.2.9</string>
+  <string>1.1</string>
   <key>ParentRecipe</key>
   <string>com.github.hansen-m.download.pycharm</string>
   <key>Process</key>

--- a/R/R-Win.download.recipe
+++ b/R/R-Win.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;exe&gt;R-(?P&lt;version&gt;[0-9.]+)-win\.exe)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>

--- a/RisingSoftware/AuraliaCloud.download.recipe
+++ b/RisingSoftware/AuraliaCloud.download.recipe
@@ -18,7 +18,7 @@
         <string>(?P&lt;url&gt;https://download\.risingsoftware\.com/auralia./cloud/auralia_m_(?P&lt;version&gt;.*?)_cloud.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/SPEAR/SPEAR.download.recipe
+++ b/SPEAR/SPEAR.download.recipe
@@ -14,7 +14,7 @@
         <string>http://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Sibelius/Sibelius.download.recipe
+++ b/Sibelius/Sibelius.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;http://cdn.avid.com/Sibelius/Sibelius_.*?/.*?/Sibelius_(?P&lt;version&gt;.*?)_Mac\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
 		<dict>

--- a/SonicVisualiser/SonicVisualiser.download.recipe
+++ b/SonicVisualiser/SonicVisualiser.download.recipe
@@ -16,7 +16,7 @@
         <string>(https://code\.soundsoftware\.ac\.uk/attachments/download/[0-9]*/Sonic%20Visualiser-[.0-9]*\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/StarkLabs/Nebulosity4-64.download.recipe
+++ b/StarkLabs/Nebulosity4-64.download.recipe
@@ -14,7 +14,7 @@
         <string>http://www.stark-labs.com/downloads_files/Nebulosity4-64.pkg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/StarkLabs/Nebulosity4-64.pkg.recipe
+++ b/StarkLabs/Nebulosity4-64.pkg.recipe
@@ -66,6 +66,17 @@
                 </array>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_pkg</key>
+                <string>%pathname%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Stellarium/Stellarium.download.recipe
+++ b/Stellarium/Stellarium.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;https://github.com.*(?P&lt;version&gt;[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}).zip)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Texmaker/Texmaker.download.recipe
+++ b/Texmaker/Texmaker.download.recipe
@@ -18,7 +18,7 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
        <dict>

--- a/Unity3D/UnityHub.download.recipe
+++ b/Unity3D/UnityHub.download.recipe
@@ -14,7 +14,7 @@
         <string>https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Xamarin/XamarinStudio.download.recipe
+++ b/Xamarin/XamarinStudio.download.recipe
@@ -16,7 +16,7 @@
         <string>(?P&lt;url&gt;http://download\.xamarin.com/studio/Mac/XamarinStudio-.*?\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Zoom/Zoom.download.recipe
+++ b/Zoom/Zoom.download.recipe
@@ -16,7 +16,7 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This PR includes these minor changes to recipes:

- Increase MinimumVersion (of AutoPkg) required based on actual processors used in each recipe
- Ensure EndOfCheckPhase is after the download process, and not in other places
- Add PkgCopier to pkg recipes that don't take other package creation actions
- Use actual app name instead of NAME in paths where overriding the name would otherwise break the recipe

