### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Adobe/AdobeFlashPlayerActiveX-Win.download.recipe
+++ b/Adobe/AdobeFlashPlayerActiveX-Win.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player_ax.exe</string>
+                <string>https://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player_ax.exe</string>
                 <key>filename</key>
                 <string>%NAME%.exe</string>
             </dict>

--- a/Adobe/AdobeFlashPlayerPPAPI-Win.download.recipe
+++ b/Adobe/AdobeFlashPlayerPPAPI-Win.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player_ppapi.exe</string>
+                <string>https://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player_ppapi.exe</string>
                 <key>filename</key>
                 <string>%NAME%.exe</string>
             </dict>

--- a/Adobe/AdobeFlashPlayerPlugin-Win.download.recipe
+++ b/Adobe/AdobeFlashPlayerPlugin-Win.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player.exe</string>
+                <string>https://fpdownload.adobe.com/get/flashplayer/pdc/%version%/install_flash_player.exe</string>
                 <key>filename</key>
                 <string>%NAME%.exe</string>
             </dict>

--- a/Adobe/AdobeReader-Win.download.recipe
+++ b/Adobe/AdobeReader-Win.download.recipe
@@ -67,7 +67,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/%packed_version%/AcroRdrDC%packed_version%_en_US.exe</string>
+                <string>https://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/%packed_version%/AcroRdrDC%packed_version%_en_US.exe</string>
                 <key>filename</key>
                 <string>%NAME%.exe</string>
                 <key>request_headers</key>

--- a/Artstor/OIV-Win.download.recipe
+++ b/Artstor/OIV-Win.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>http://internal.artstor.org/global/g-html/download-oiv-participant.html</string>
         <key>BASE_URL</key>
-        <string>http://www.artstor.org</string>
+        <string>https://www.artstor.org</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12</string>
     </dict>

--- a/Artstor/OIV.download.recipe
+++ b/Artstor/OIV.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>http://internal.artstor.org/global/g-html/download-oiv-participant.html</string>
         <key>BASE_URL</key>
-        <string>http://www.artstor.org</string>
+        <string>https://www.artstor.org</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14</string>
     </dict>

--- a/FirestormViewer/FirestormOSRelease.download.recipe
+++ b/FirestormViewer/FirestormOSRelease.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>FirestormOS</string>
         <key>SEARCH_URL</key>
-        <string>http://www.firestormviewer.org/mac/</string>
+        <string>https://www.firestormviewer.org/mac/</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;http://downloads\.firestormviewer\.org/mac/Phoenix-FirestormOS-Releasex64-.*?\.dmg)</string>
     </dict>

--- a/FirestormViewer/FirestormRelease.download.recipe
+++ b/FirestormViewer/FirestormRelease.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Firestorm</string>
         <key>SEARCH_URL</key>
-        <string>http://www.firestormviewer.org/mac/</string>
+        <string>https://www.firestormviewer.org/mac/</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;http://downloads\.firestormviewer\.org/mac/Phoenix-Firestorm-Release-.*?\.dmg)</string>
     </dict>

--- a/Mendeley/Mendeley-Win.download.recipe
+++ b/Mendeley/Mendeley-Win.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Mendeley</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.mendeley.com/client/get/1/</string>
+        <string>https://www.mendeley.com/client/get/1/</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko</string>
     </dict>

--- a/Microsoft/Silverlight-Win.download.recipe
+++ b/Microsoft/Silverlight-Win.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Silverlight</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.microsoft.com/getsilverlight/handlers/getsilverlight.ashx</string>
+        <string>https://www.microsoft.com/getsilverlight/handlers/getsilverlight.ashx</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Windows NT 6.2; WOW64; rv:23.0) Gecko/20100101 Firefox/23.0</string>
     </dict>

--- a/OpenText/ExceedOnDemand.download.recipe
+++ b/OpenText/ExceedOnDemand.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Exceed onDemand Client</string>
         <key>SEARCH_URL</key>
-        <string>http://connectivity.opentext.com/products/mac-os-x-platforms.aspx</string>
+        <string>https://connectivity.opentext.com/products/mac-os-x-platforms.aspx</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;http://mimage\.opentext\.com/patches/connectivity/eod8/[a-z0-9_]+/[a-z0-9]+/mac/eodclient.-(?P&lt;version&gt;[0-9.]+)\.dmg)</string>
     </dict>

--- a/Polycom/PolycomCMADesktop.download.recipe
+++ b/Polycom/PolycomCMADesktop.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>PolycomCMADesktop</string>
         <key>SEARCH_URL</key>
-        <string>http://support.polycom.com/PolycomService/support/us/support/video/cma/cma_desktop.html</string>
+        <string>https://support.polycom.com/PolycomService/support/us/support/video/cma/cma_desktop.html</string>
         <key>POLYCOMCMADESKTOP_REPATTERN</key>
         <string>http://downloads\.polycom\.com/net_endpt_mgmt/cmad_mac/CMAD-release_(?P&lt;version&gt;.*?)\.dmg</string>
     </dict>

--- a/SPEAR/SPEAR.download.recipe
+++ b/SPEAR/SPEAR.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>SPEAR</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg</string>
+        <string>https://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>

--- a/StarkLabs/Nebulosity4-64.download.recipe
+++ b/StarkLabs/Nebulosity4-64.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Nebulosity4</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.stark-labs.com/downloads_files/Nebulosity4-64.pkg</string>
+        <string>https://www.stark-labs.com/downloads_files/Nebulosity4-64.pkg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>

--- a/StarkLabs/Nebulosity4-64.pkg.recipe
+++ b/StarkLabs/Nebulosity4-64.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Nebulosity4</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.stark-labs.com/downloads_files/Nebulosity4-64.pkg</string>
+        <string>https://www.stark-labs.com/downloads_files/Nebulosity4-64.pkg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/ThomsonReuters/EndNote-Win.download.recipe
+++ b/ThomsonReuters/EndNote-Win.download.recipe
@@ -13,7 +13,7 @@
         <key>ENDNOTE_MAJOR_VERSION</key>
         <string>X8</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://download.endnote.com/downloads/%ENDNOTE_MAJOR_VERSION%/EN%ENDNOTE_MAJOR_VERSION%Inst.msi</string>
+        <string>https://download.endnote.com/downloads/%ENDNOTE_MAJOR_VERSION%/EN%ENDNOTE_MAJOR_VERSION%Inst.msi</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/UnixUtils/7zip-Win.download.recipe
+++ b/UnixUtils/7zip-Win.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>7zip</string>
         <key>SEARCH_URL</key>
-        <string>http://7-zip.org/download.html</string>
+        <string>https://7-zip.org/download.html</string>
         <key>SEARCH_PATTERN</key>
         <string>a/7z[0-9]+\.msi</string>
     </dict>
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://d.7-zip.org/%match%</string>
+                <string>https://d.7-zip.org/%match%</string>
                 <key>filename</key>
                 <string>%NAME%.msi</string>
             </dict>

--- a/UnixUtils/7zip-Win64.download.recipe
+++ b/UnixUtils/7zip-Win64.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>7zip</string>
         <key>SEARCH_URL</key>
-        <string>http://7-zip.org/download.html</string>
+        <string>https://7-zip.org/download.html</string>
         <key>SEARCH_PATTERN</key>
         <string>a/7z[0-9]+-x64\.msi</string>
     </dict>
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://d.7-zip.org/%match%</string>
+                <string>https://d.7-zip.org/%match%</string>
                 <key>filename</key>
                 <string>%NAME%.msi</string>
             </dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._