### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Amazon/Kindle.pkg.recipe
+++ b/Amazon/Kindle.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.amazon.Kindle</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Aquamacs/Aquamacs.pkg.recipe
+++ b/Aquamacs/Aquamacs.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>org.gnu.Aquamacs.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Astronomy/AstroImageJ.pkg.recipe
+++ b/Astronomy/AstroImageJ.pkg.recipe
@@ -86,8 +86,6 @@
                         <string>%pkgroot%</string>
                         <key>id</key>
                         <string>edu.louisville.astro.AstroImageJ.pkg</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Astronomy/SAOImageDS9.pkg.recipe
+++ b/Astronomy/SAOImageDS9.pkg.recipe
@@ -87,8 +87,6 @@
                     <string>com.github.hansen-m.pkg.SAOImageDS9</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/BESEngine/BESEngine.pkg.recipe
+++ b/BESEngine/BESEngine.pkg.recipe
@@ -151,8 +151,6 @@
                     <string>edu.psu.pkg.BESEngine</string>
                     <key>infofile</key>
                     <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/BESPythonAPI/BESPythonAPI.pkg.recipe
+++ b/BESPythonAPI/BESPythonAPI.pkg.recipe
@@ -216,8 +216,6 @@
                     <string>%RECIPE_CACHE_DIR%/</string>
                     <key>id</key>
                     <string>edu.psu.pkg.BESPythonAPI</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/BigFix/QnA.pkg.recipe
+++ b/BigFix/QnA.pkg.recipe
@@ -138,8 +138,6 @@
                     <string>com.ibm.bigfix.qna</string>
                     <key>infofile</key>
                     <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Box/BoxSync.pkg.recipe
+++ b/Box/BoxSync.pkg.recipe
@@ -121,8 +121,6 @@
                     <string>com.box.pkg.boxsync</string>
                     <key>infofile</key>
                     <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/CodingMonkeys/SubEthaEdit.pkg.recipe
+++ b/CodingMonkeys/SubEthaEdit.pkg.recipe
@@ -74,8 +74,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.thecodingmonkeys.%NAME%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -73,8 +73,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>org.gnome.gimp</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/McNeel/Rhino.pkg.recipe
+++ b/McNeel/Rhino.pkg.recipe
@@ -81,8 +81,6 @@
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>
                         <string>%bundleid%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Mendeley/Mendeley.pkg.recipe
+++ b/Mendeley/Mendeley.pkg.recipe
@@ -79,8 +79,6 @@
                    <string>com.mendeley.desktop.pkg</string>
                    <key>resources</key>
                    <string>Resources</string>
-                   <key>options</key>
-                   <string>purge_ds_store</string>
                    <key>chown</key>
                    <array>
                        <dict>

--- a/Microbiology/Mothur.pkg.recipe
+++ b/Microbiology/Mothur.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>com.github.mothur.pkg.mothur</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/PyCharm/PyCharm.pkg.recipe
+++ b/PyCharm/PyCharm.pkg.recipe
@@ -69,8 +69,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Texmaker/Texmaker.pkg.recipe
+++ b/Texmaker/Texmaker.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>net.xm1math.texmaker</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._