### PR TITLE
Deprecate Processing recipes

### DIFF
--- a/Processing/Processing.download.recipe
+++ b/Processing/Processing.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Processing recipes in the timsutton-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>


### PR DESCRIPTION
The Processing.download recipe in this repo is similar in function to the earlier-created one in timsutton-recipes. This PR deprecates the one in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!