### PR TITLE
Update Intel option

### DIFF
--- a/Unity3D/UnityHub.download.recipe.yaml
+++ b/Unity3D/UnityHub.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: 2.7.6
 
 Input:
   NAME: UnityHub
-  BUILD: arm64 # Options: arm64, x86
+  BUILD: arm64 # Options: arm64, x64
 
 Process:
   - Processor: URLDownloader


### PR DESCRIPTION
x86 is the wrong link to the Intel version of the hub. It should be x64.