### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Adobe/AdobeAIR-Win.download.recipe
+++ b/Adobe/AdobeAIR-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -74,10 +78,6 @@
                     <string>%RECIPE_CACHE_DIR%/SetupExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
@@ -29,6 +29,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 				<key>Processor</key>
 				<string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
 				<key>Arguments</key>
@@ -64,10 +68,6 @@
 								<string>%RECIPE_CACHE_DIR%/InstallerExtract</string>
 						</array>
 				</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Adobe/AdobeShockwavePlayer-Win.download.recipe
+++ b/Adobe/AdobeShockwavePlayer-Win.download.recipe
@@ -30,16 +30,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Apple/QuickTime-Win.download.recipe
+++ b/Apple/QuickTime-Win.download.recipe
@@ -63,6 +63,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -91,10 +95,6 @@
                     <string>%RECIPE_CACHE_DIR%/EXEExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Apple/iTunes-Win.download.recipe
+++ b/Apple/iTunes-Win.download.recipe
@@ -10,7 +10,7 @@
     <dict>
         <key>NAME</key>
         <string>iTunes</string>
-        <!--Downloads 64 bit version by default. Uncomment following win32 url or override to get 32bit version--> 
+        <!--Downloads 64 bit version by default. Uncomment following win32 url or override to get 32bit version-->
         <!--<key>DOWNLOAD_URL</key>
         <string>https://www.apple.com/itunes/download/win32</string>-->
         <key>DOWNLOAD_URL</key>
@@ -37,6 +37,10 @@
                 <key>filename</key>
                 <string>%NAME%.exe</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -81,10 +85,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Box/BoxEdit-Win.download.recipe
+++ b/Box/BoxEdit-Win.download.recipe
@@ -30,16 +30,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Box/BoxSync-Win.download.recipe
+++ b/Box/BoxSync-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/HachoirMetaDataProvider</string>
             <key>Arguments</key>
             <dict>
@@ -49,10 +53,6 @@
                 <key>bes_relevance</key>
                 <string>(if (last 2 of it = ".0") then substring (0, length of it - 2) of it else it) of "%version%"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Code42/CrashPlan-Linux.download.recipe
+++ b/Code42/CrashPlan-Linux.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -58,10 +62,6 @@
                 <key>output_var_name</key>
                 <string>version</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Code42/CrashPlan-Win.download.recipe
+++ b/Code42/CrashPlan-Win.download.recipe
@@ -28,16 +28,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Code42/CrashPlan-Win64.download.recipe
+++ b/Code42/CrashPlan-Win64.download.recipe
@@ -28,16 +28,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/CodingMonkeys/SubEthaEdit.download.recipe
+++ b/CodingMonkeys/SubEthaEdit.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "de.codingmonkeys.SubEthaEdit.MacFULL" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S76GCAG929)</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Dymo/DymoLabel-Win.download.recipe
+++ b/Dymo/DymoLabel-Win.download.recipe
@@ -56,6 +56,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -88,10 +92,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -52,6 +52,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
@@ -60,10 +64,6 @@
                 <key>requirement</key>
                 <string>identifier "org.gimp.gimp-2.10" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T25BQ8HSJF</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Google/GoogleChrome-Win.download.recipe
+++ b/Google/GoogleChrome-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/GoogleChromeWinVersioner</string>
             <key>Arguments</key>
             <dict>
@@ -49,10 +53,6 @@
                     <string>%RECIPE_CACHE_DIR%/InstallerExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Google/GoogleChrome-Win64.download.recipe
+++ b/Google/GoogleChrome-Win64.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/GoogleChromeWinVersioner</string>
             <key>Arguments</key>
             <dict>
@@ -49,10 +53,6 @@
                     <string>%RECIPE_CACHE_DIR%/InstallerExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Google/GoogleEarth-Win.download.recipe
+++ b/Google/GoogleEarth-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -58,10 +62,6 @@
                     <string>%RECIPE_CACHE_DIR%/InstallerExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Google/GoogleEarthPro-Win.download.recipe
+++ b/Google/GoogleEarthPro-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -58,10 +62,6 @@
                     <string>%RECIPE_CACHE_DIR%/InstallerExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Greenshot/Greenshot-Win.download.recipe
+++ b/Greenshot/Greenshot-Win.download.recipe
@@ -42,6 +42,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>BESRelevanceProvider</string>
             <key>Arguments</key>
             <dict>
@@ -52,10 +56,6 @@
                 <key>bes_relevance</key>
                 <string>(it as version) of (following text of first "-RELEASE-" of "%version%" | "%version%")</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Inkscape/Inkscape.download.recipe
+++ b/Inkscape/Inkscape.download.recipe
@@ -15,11 +15,11 @@
         <key>SEARCH_PATTERN1</key>
         <string>(/release/([0-9]{1,3}.[0-9]{0,3}.[0-9]{0,3})/mac-os-x/)</string>
         <key>SEARCH_PATTERN2</key>
-        <string>(/%ARCHITECTURE%/dl)</string>  
+        <string>(/%ARCHITECTURE%/dl)</string>
         <key>SEARCH_PATTERN3</key>
-        <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>  
+        <string>(?P&lt;dmgurl&gt;\/gallery\/.*Inkscape.*dmg)</string>
         <key>ARCHITECTURE</key>
-        <string>dmg</string>  
+        <string>dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>
@@ -77,6 +77,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
@@ -94,10 +98,6 @@
                 <key>requirement</key>
                 <string>identifier "org.inkscape.Inkscape" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SW3D6BB6A6</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/MakerBot/MakerBotPrint-Win.download.recipe
+++ b/MakerBot/MakerBotPrint-Win.download.recipe
@@ -52,6 +52,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                 <key>result_output_var_name</key>
                 <string>version</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/MakerBot/MakerBotPrint.download.recipe
+++ b/MakerBot/MakerBotPrint.download.recipe
@@ -51,6 +51,10 @@
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
            <key>Processor</key>
             <string>FlatPkgUnpacker</string>
             <key>Arguments</key>
@@ -94,10 +98,6 @@
             </dict>
             <key>Processor</key>
             <string>PathDeleter</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Mendeley/Mendeley-Win.download.recipe
+++ b/Mendeley/Mendeley-Win.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -65,10 +69,6 @@
                     <string>%RECIPE_CACHE_DIR%/EXEExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft/Silverlight-Win.download.recipe
+++ b/Microsoft/Silverlight-Win.download.recipe
@@ -37,16 +37,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/HachoirMetaDataProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>file_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Mozilla/Firefox-Win.download.recipe
+++ b/Mozilla/Firefox-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Mozilla/Firefox64-Win.download.recipe
+++ b/Mozilla/Firefox64-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Mozilla/FirefoxESR-Win.download.recipe
+++ b/Mozilla/FirefoxESR-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Mozilla/FirefoxESR64-Win.download.recipe
+++ b/Mozilla/FirefoxESR64-Win.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%/ExeExtract</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/PollEverywhere/PollEverywhere-Win.download.recipe
+++ b/PollEverywhere/PollEverywhere-Win.download.recipe
@@ -28,6 +28,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/ExeVersionExtractor</string>
             <key>Arguments</key>
             <dict>
@@ -59,10 +63,6 @@
                 </array>
             </dict>
         </dict> -->
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/PollEverywhere/PollEverywhere.download.recipe
+++ b/PollEverywhere/PollEverywhere.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PlistReader</string>
             <key>Arguments</key>
             <dict>
@@ -48,10 +52,6 @@
                      <string>version</string>
                  </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/PreyProject/Prey.download.recipe
+++ b/PreyProject/Prey.download.recipe
@@ -60,12 +60,16 @@
                 <string>%NAME%.pkg</string>
             </dict>
         </dict>
-        <dict>   
-            <key>Processor</key>   
-            <string>CodeSignatureVerifier</string>   
-            <key>Arguments</key>   
-            <dict>   
-                <key>input_path</key>   
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
@@ -74,10 +78,6 @@
                     <string>Apple Root CA</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/ProjectLibre/ProjectLibre.download.recipe
+++ b/ProjectLibre/ProjectLibre.download.recipe
@@ -34,16 +34,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
                 <string>%pathname%/ProjectLibre.app/Contents/Info.plist</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Skype/Skype-Win.download.recipe
+++ b/Skype/Skype-Win.download.recipe
@@ -37,16 +37,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/ThomsonReuters/EndNote-Win.download.recipe
+++ b/ThomsonReuters/EndNote-Win.download.recipe
@@ -32,16 +32,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Unity3D/UnityHub.download.recipe.yaml
+++ b/Unity3D/UnityHub.download.recipe.yaml
@@ -12,6 +12,8 @@ Process:
       url: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-%BUILD%.dmg"
       filename: "%NAME%.dmg"
 
+  - Processor: EndOfCheckPhase
+
   - Processor: CodeSignatureVerifier
     Arguments:
       input_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Unity Hub.app"
@@ -20,5 +22,3 @@ Process:
   - Processor: Versioner
     Arguments:
       input_plist_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Unity Hub.app/Contents/Info.plist"
-
-  - Processor: EndOfCheckPhase

--- a/UnixUtils/7zip-Win.download.recipe
+++ b/UnixUtils/7zip-Win.download.recipe
@@ -54,16 +54,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/UnixUtils/7zip-Win64.download.recipe
+++ b/UnixUtils/7zip-Win64.download.recipe
@@ -54,16 +54,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Zoom/Zoom-Win.download.recipe
+++ b/Zoom/Zoom-Win.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.jgstew.SharedProcessors/FileMsiGetProperty</string>
             <key>Arguments</key>
             <dict>
@@ -45,10 +49,6 @@
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Zoom/Zoom64-Win.download.recipe
+++ b/Zoom/Zoom64-Win.download.recipe
@@ -35,16 +35,16 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>msi_path</key>
                 <string>%pathname%</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.