### PR TITLE
Update installer type and search pattern in recipe

### DIFF
--- a/Continuum/Anaconda.download.recipe
+++ b/Continuum/Anaconda.download.recipe
@@ -36,18 +36,7 @@ to chose between 'sh' or 'pkg'.</string>
                 <key>url</key>
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
-                <string>Python (?P&lt;PYTHON_VERSION&gt;%PYTHON_MAJOR_VERSION%\.\d)</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string> 
+                <string>%SEARCH_PATTERN%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @rustymyers 

The Anaconda recipe is currently failing with 
```
URLTextSearcher: Error: No match found on URL: https://www.anaconda.com/download/success
```

It's actually failing on the first step, which I believe is obsolete this PR removes that first URLTextSearcher step.

Output from a successful -v run 
```
autopkg run -v Anaconda.download.recipe
Processing Anaconda.download.recipe...
WARNING: Anaconda.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): https://repo.anaconda.com/archive/Anaconda3-2025.06-0-MacOSX-x86_64.pkg
URLTextSearcher: Found matching text (version): 2025.06-0
URLTextSearcher: Found matching text (match): https://repo.anaconda.com/archive/Anaconda3-2025.06-0-MacOSX-x86_64.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 23 Jun 2025 18:32:47 GMT
URLDownloader: Storing new ETag header: "5d487e00fafc2da2299695de783fc78a-97"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3-2025.06-0.pkg
EndOfCheckPhase
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/receipts/Anaconda.download-receipt-20251124-140206.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.hansen-m.download.Anaconda/downloads/Anaconda3-2025.06-0.pkg 
```