### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Astronomy/AstroImageJ_Updates.download.recipe
+++ b/Astronomy/AstroImageJ_Updates.download.recipe
@@ -11,7 +11,7 @@
             <key>NAME</key>
             <string>AstroImageJ Updates</string>
             <key>JAR_URL</key>
-            <string>http://www.astro.louisville.edu/software/astroimagej/updates/updatesjava17</string>
+            <string>https://www.astro.louisville.edu/software/astroimagej/updates/updatesjava17</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.9</string>

--- a/ImgBurn/ImgBurn-Win.download.recipe
+++ b/ImgBurn/ImgBurn-Win.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://download.imgburn.com/SetupImgBurn_%version%.exe</string>
+                <string>https://download.imgburn.com/SetupImgBurn_%version%.exe</string>
                 <key>filename</key>
                 <string>%NAME%.exe</string>
             </dict>

--- a/MacTeX/MacTeX.download.recipe
+++ b/MacTeX/MacTeX.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>MacTeX</string>
         <key>DOWNLOADPAGE_URL</key>
-        <string>http://www.tug.org/mactex/mactex-download.html</string>
+        <string>https://www.tug.org/mactex/mactex-download.html</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._