### PR TITLE
Deprecate MacTeX recipes

### DIFF
--- a/MacTeX/MacTeX.download.recipe
+++ b/MacTeX/MacTeX.download.recipe
@@ -14,9 +14,18 @@
         <string>https://www.tug.org/mactex/mactex-download.html</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to MacTeX recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [MacTeX download recipe in joshua-d-miller-recipes](https://github.com/autopkg/joshua-d-miller-recipes/blob/master/MacTeX/mactex.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **CodeSignatureVerifier** — joshua-d-miller-recipes verifies the installer's code signature, providing an additional layer of trust

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!