### PR TITLE
Update download url and regex

### DIFF
--- a/RStudio/RStudio-Win.download.recipe
+++ b/RStudio/RStudio-Win.download.recipe
@@ -11,9 +11,9 @@
             <key>NAME</key>
             <string>RStudio</string>
             <key>SEARCH_URL</key>
-            <string>https://live-rstudio.pantheonsite.io/download/rstudio-desktop/</string>
+            <string>https://docs.posit.co/ide/user/#rstudio-ide-oss-downloads</string>
             <key>SEARCH_PATTERN</key>
-            <string>(?P&lt;exe&gt;RStudio-(?P&lt;version&gt;([0-9.]+){1,3}?.*).exe)</string>
+            <string>(?P&lt;exe&gt;RStudio-(?P&lt;version&gt;([0-9.-]+){1,3}?).exe)</string>
             <key>DOWNLOAD_MIRROR</key>
             <string>https://download1.rstudio.org/electron/windows</string>
         </dict>


### PR DESCRIPTION
download failing, previous download url not working, regex was pulling RStudio-2026.07.1-147.exe"><code>RStudio-2026.07.1-147.exe as the exe name