### PR TITLE
regex not matching on https://7-zip.org/download.html

### DIFF
--- a/UnixUtils/7zip-Win64.download.recipe
+++ b/UnixUtils/7zip-Win64.download.recipe
@@ -10,36 +10,25 @@
     <dict>
         <key>NAME</key>
         <string>7zip</string>
-        <key>SEARCH_URL</key>
-        <string>https://7-zip.org/download.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>a/7z[0-9]+-x64\.msi</string>
+        <string>7z[0-9]+-x64\.msi</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>Process</key>
     <array>
-      <dict>
+        <dict>
           <key>Processor</key>
-          <string>URLTextSearcher</string>
+          <string>GitHubReleasesInfoProvider</string>
           <key>Arguments</key>
           <dict>
-              <key>url</key>
-              <string>%SEARCH_URL%</string>
-              <key>re_pattern</key>
+              <key>github_repo</key>
+              <string>ip7z/7zip</string>
+              <key>asset_regex</key>
               <string>%SEARCH_PATTERN%</string>
+              <key>latest_only</key>
+              <string>True</string>
           </dict>
-      </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -47,23 +36,14 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://d.7-zip.org/%match%</string>
+                <string>%url%</string>
                 <key>filename</key>
-                <string>%NAME%.msi</string>
+                <string>%NAME%-%version%-x64.msi</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>com.github.hansen-m.SharedProcessors/MSIInfoVersionProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>msi_path</key>
-                <string>%pathname%</string>
-            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Only getting the 23.x version, getting from Github releases instead: https://github.com/ip7z/7zip/